### PR TITLE
chore(build): update grunt build to build all themes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
   require('load-grunt-config')(grunt, {
     data: {
       themedir: './themes',
-      buildtheme: 'global',
+      buildtheme: 'all',
       themes: ['global', 'derek']
     }
   });

--- a/grunt/build.js
+++ b/grunt/build.js
@@ -4,6 +4,14 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', 'build a theme', function (themename) {
     var theme = themename === undefined ? grunt.config('buildtheme') : themename;
+
+    if (theme == 'all') {
+      grunt.config('themes').forEach(function(item) {
+        grunt.task.run(['build:' + item]);
+      });
+      return;
+    }
+
     var themedir = grunt.config('themedir');
 
     var isValidTheme = grunt.file.exists(themedir, theme, 'scss', 'build.scss');
@@ -14,7 +22,7 @@ module.exports = function (grunt) {
 
     grunt.task.run(['scss:' + theme, 'js:' + theme, 'copy']);
 
-  });
+    });
 
   grunt.registerTask('scss', 'build scss', function (themename) {
 


### PR DESCRIPTION
* Running `grunt build` will run build scripts for all themes. Previously, it defaulted to `global`. 
* Added new `all` parameter to build task. `grunt build:all`