### PR TITLE
Add ceiling navigation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
       buildtheme: 'all',
       themes: ['global', 'derek'],
       version: '1.1',
-      cdn_url: 'https://brand.rax.io' // fixme: does not work as cname with cloud files
+      cdnurl: 'https://brand.rax.io' // fixme: does not work as cname with cloud files
     }
   });
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,9 @@ module.exports = function (grunt) {
     data: {
       themedir: './themes',
       buildtheme: 'all',
-      themes: ['global', 'derek']
+      themes: ['global', 'derek'],
+      version: '1.1',
+      cdn_url: 'https://brand.rax.io' // fixme: does not work as cname with cloud files
     }
   });
 };

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,6 +7,7 @@
   <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
   <meta name="description" content="">
   <meta name="author" content="">
+  <meta name="format-detection" content="telephone=no" />
   <link rel="icon" href="/favicon.ico">
 
   <title>Zoolander Style Guide</title>
@@ -59,7 +60,5 @@
 
 
 <script src="/dist/global/js/global.bundle.js"></script>
-<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
 </body>
 </html>

--- a/docs/derek/components/navigation.html
+++ b/docs/derek/components/navigation.html
@@ -11,45 +11,186 @@ css: /dist/derek/css/derek.css
 </ul>
 
 <h2>Ceiling Navigation</h2>
-<p>Links on the left and drop down buttons on the right.</p>
+<p>If present, this element should be the top most element on a web page.</p>
+<p>It is recommended to use a combination of links with labels as well as button drop downs.</p>
 
-<h3>Ceiling Variation #1 [WIP]</h3>
+
+<h3><span class="badge alert-warning"> WIP </span> Ceiling Menu Links</h3>
+<p>Various combinations on achieving links with labels within the ceiling navigation.</p>
+<p></p>
+<a href="#">Back to Top</a>
+
 {% example html %}
-<nav class="ceiling">
-  <dl class="navbar-left">
-    <dt><a href="#">Support</a></dt>
-    <dd>1-800-000-0000</dd>
-    <dt><a href="#">Sales</a></dt>
-    <dd class="last">1-800-000-0000</dd>
-  </dl>
+<div class="ceiling" role="menubar">
+  <nav class="navbar-left">
+    <ul class="menu-inline" role="menu">
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <a href="tel:+18000000000" role="menuitem" title="Link Description">Link Only</a>
+      </li>
+      <li>
+        <label>Label w/o Link</label>
+        <a href="tel:+18000000000" role="menuitem" title="Link Described by Label">Some Link</a>
+      </li>
+      <li>
+        Text Only
+      </li>
+    </ul>
+  </nav>
+</div>
+{% endexample %}
 
-  <div class="navbar-right">
+<h3><span class="badge alert-warning"> WIP </span> Ceiling Menu Links Right Side</h3>
+<p>Switch to the right side of ceiling</p>
+<p></p>
+<a href="#">Back to Top</a>
+
+{% example html %}
+<div class="ceiling" role="menubar">
+  <nav class="navbar-right">
+    <ul class="menu-inline" role="menu">
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <a href="tel:+18000000000" role="menuitem" title="Link Description">Link Only</a>
+      </li>
+      <li>
+        <label>Label w/o Link</label>
+        <a href="tel:+18000000000" role="menuitem" title="Link Described by Label">Some Link</a>
+      </li>
+      <li>
+        Text Only
+      </li>
+    </ul>
+  </nav>
+</div>
+
+{% endexample %}
+
+
+<h3><span class="badge alert-warning"> WIP </span> Ceiling Menu Links Both Sides</h3>
+<p>Combination</p>
+<a href="#">Back to Top</a>
+
+{% example html %}
+<div class="ceiling" role="menubar">
+  <nav class="navbar-left">
+    <ul class="menu-inline" role="menu">
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+    </ul>
+  </nav>
+  <nav class="navbar-right">
+    <ul class="menu-inline" role="menu">
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+      <li>
+        <label><a href="javascript:" role="menuitem">Support</a></label>
+        <a href="tel:+18000000000" role="menuitem" title="Support Phone Number">1-800-000-0000</a>
+      </li>
+    </ul>
+  </nav>
+
+</div>
+
+{% endexample %}
+
+<h3><span class="badge alert-warning"> WIP </span> Ceiling Buttons</h3>
+<p>Buttons</p>
+<a href="#">Back to Top</a>
+
+{% example html %}
+<div class="ceiling" role="menubar">
+  <nav class="navbar-left">
     <ul class="nav navbar-nav">
-      <li class="dropdown primary">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Signup</a>
+      <li class="dropdown">
+        <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="#">Rackspace Cloud</a></li>
-          <li><a href="#">Cloud Sites</a></li>
-          <li><a href="#">Cloud Office</a></li>
+          <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+          <li><a href="#" role="menuitem">Cloud Sites</a></li>
+          <li><a href="#" role="menuitem">Cloud Office</a></li>
         </ul>
       </li>
       <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Login</a>
+        <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="https://my.rackspace.com/portal/auth/login">MyRackspace Portal</a></li>
-          <li><a href="https://mycloud.rackspace.com">Cloud Control Panel</a></li>
-          <li><a href="https://manage.rackspacecloud.com/pages/Login.jsp">Cloud Sites Control Panel</a></li>
-          <li><a href="https://apps.rackspace.com">Rackspace Webmail Login</a></li>
-          <li><a href="https://cp.rackspace.com">Email Admin Login</a></li>
+          <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+          <li><a href="#" role="menuitem">Cloud Sites</a></li>
+          <li><a href="#" role="menuitem">Cloud Office</a></li>
         </ul>
       </li>
     </ul>
-  </div>
-  <dl class="navbar-right">
-    <dd><a href="#">Partners</a></dd>
-    <dd class="last"><a href="#">Sales</a></dd>
-  </dl>
-</nav>
+  </nav>
+  <nav class="navbar-right">
+    <ul class="nav navbar-nav">
+      <li class="dropdown">
+        <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
+        <ul class="dropdown-menu" role="menu">
+          <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+          <li><a href="#" role="menuitem">Cloud Sites</a></li>
+          <li><a href="#" role="menuitem">Cloud Office</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
+        <ul class="dropdown-menu" role="menu">
+          <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+          <li><a href="#" role="menuitem">Cloud Sites</a></li>
+          <li><a href="#" role="menuitem">Cloud Office</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+</div>
+{% endexample %}
 
-<div class="clearfix"></div>
+
+<h3><span class="badge alert-warning"> WIP </span> Ceiling with Collapse</h3>
+<p>Buttons</p>
+<a href="#">Back to Top</a>
+
+{% example html %}
+<div class="ceiling" role="menubar">
+    <nav class="navbar-right">
+      <ul class="nav navbar-nav">
+        <li class="dropdown">
+          <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+            <li><a href="#" role="menuitem">Cloud Sites</a></li>
+            <li><a href="#" role="menuitem">Cloud Office</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="javascript:" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Menu</a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="#" role="menuitem">Rackspace Cloud</a></li>
+            <li><a href="#" role="menuitem">Cloud Sites</a></li>
+            <li><a href="#" role="menuitem">Cloud Office</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+</div>
 {% endexample %}

--- a/docs/derek/index.md
+++ b/docs/derek/index.md
@@ -6,18 +6,18 @@ theme_name: derek
 
 # Derek Theme
 
-## Work in progress 
 
 **[insert 90s style gif of man in hard hat swinging hammer]**
 
 ### CSS
+
 {% highlight html %}
-<link href="https://path/to/cdn/derek/css/derek.css" rel="stylesheet">
+<link href="https://brand.rax.io/v1.1/derek/css/derek.css" rel="stylesheet">
 {% endhighlight %}
 
 ### Javascript
 {% highlight html %}
-<script src="https://path/to/cdn/derek/js/bundle.js"></script>
+<script src="https://brand.rax.io/v1.1/derek/js/bundle.js"></script>
 {% endhighlight %}
 
-
+<img src="https://brand.rax.io/v1.1/a" />

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -1,14 +1,14 @@
 module.exports = {
   scripts: {
     files: ['themes/**/*.js'],
-    tasks: ['jshint', 'jscs', 'js'],
+    tasks: ['jshint', 'jscs', 'js', 'copy'],
     options: {
       spawn: false
     }
   },
   scss: {
     files: ['themes/**/*.scss'],
-    tasks: ['scss'],
+    tasks: ['scss', 'copy'],
     options: {
       spawn: false
     }

--- a/themes/derek/scss/components/navigation.scss
+++ b/themes/derek/scss/components/navigation.scss
@@ -1,55 +1,62 @@
+$ceiling-margin: floor($navbar-margin-bottom / 2);
 
 .ceiling{
   @extend .navbar;
   @extend .navbar-default;
-  @extend .hidden-sm;
-  @extend .hidden-xs;
+  @extend .visible-md;
+  @extend .visible-lg;
 
   margin: 0;
+  min-height: $line-height-computed;
 
-  dl {
-    margin: 0 15px;
-
-    dt,dd{
-      display: inline-block;
-      margin: 15px 0;
-    }
-
-    dt a {
-      position: relative;
-      display: block;
-    }
-
-    dt a::after {
-      content: ": ";
-    }
-    dd.last::after {
-      content: " ";
-    }
-    dd::after {
-      content: " | ";
-    }
+  a {
+    color: $text-color;
   }
-  .navbar-right {
-    margin-right: 0;
-    padding-right: 10px;
+
+  .navbar-nav {
+    margin-bottom: $ceiling-margin;
+  }
+
+  .navbar-left:first-child {
+    margin-left: 0;
+    padding-left: $ceiling-margin;
+  }
+
+  .navbar-right{
+    ul.dropdown-menu {
+      margin-right: floor($ceiling-margin / 2);
+    }
+    &:last-child{
+      margin-right: 0;
+      padding-right: $ceiling-margin;
+    }
   }
 
   .dropdown{
     > a {
       @extend .btn;
       @extend .btn-default;
-      margin-top: 8px;
-      margin-right: 5px;
+      margin-top: $ceiling-margin;
+      margin-right: floor($ceiling-margin / 2);
     }
   }
-  // Increase specificity with additional tags to avoid !importants
-  .nav li.dropdown.primary > a  {
-    background-color: $btn-success-bg;
-    color: $btn-success-color;
-  }
-  .nav li.dropdown.primary > a:hover  {
-    background-color: $btn-success-bg;
+
+  ul.menu-inline {
+    @extend .list-inline;
+    margin-bottom: 0;
+
+    li{
+      margin: $ceiling-margin 0;
+    }
+
+    label::after {
+      content: ": ";
+    }
+    li::after {
+      content: " | ";
+    }
+    li:last-child::after {
+      content: " ";
+    }
   }
 }
-


### PR DESCRIPTION
These changes were based on rackspace.com
* Multiple variations for ceiling navigation. 
* Defaults to hidden in small viewports (This needs to improved to allow for responsive versions)

**Note** This PR does not try to reproduce the styles exactly as it exists today. #10 will need to be completed before styling is addressed

**Ceiling with buttons**
![screen shot 2015-10-12 at 5 42 52 pm](https://cloud.githubusercontent.com/assets/1927917/10440901/c6ee36ae-7108-11e5-91b0-9618f17d7443.png)

**Ceiling with labels and links**
![screen shot 2015-10-12 at 5 42 34 pm](https://cloud.githubusercontent.com/assets/1927917/10440902/c6ee7f88-7108-11e5-8d81-4814a95d82f0.png)

**Drop Down when in navbar-left**
![screen shot 2015-10-12 at 5 43 15 pm](https://cloud.githubusercontent.com/assets/1927917/10440900/c6edf9be-7108-11e5-8a31-756e8df75ea0.png)
**Drop Down when in navbar-right**
![screen shot 2015-10-12 at 5 43 06 pm](https://cloud.githubusercontent.com/assets/1927917/10440899/c6ed9c1c-7108-11e5-829e-3bddd1ede894.png)

