### PR TITLE
refactor(npm): expand on install, build and server tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,32 @@ Derek Zoolander's Corporate Style Guide to Help Product Teams Build Ridiculously
 ## Install
 
 ```
-gem install bundler
-npm run build
+gem install bundler jekyll
+npm install
 ```
 
 ## Build
 
 ```
-grunt build
+npm run build
 # Files saved to ./dist/[theme]
+
 # by theme
 grunt build:[theme]
 # example
 grunt build:derek
 ```
 
+## Docs
+
+```
+npm run server
+```
+
+Visit http://127.0.0.1:4000/
+
 ## Deploy
 
 ```
 rsync -a docs/_site/ deploy@10.14.209.72:/usr/share/nginx/html/
 ```
-
-

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap-sass": "bootstrap-sass-official#~3.3.5"
+    "bootstrap-sass": "bootstrap-sass-official#~3.3.5",
+    "jquery": "~2.1.4"
   }
 }

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 _site
 .sass-cache
+.jekyll-metadata

--- a/package.json
+++ b/package.json
@@ -6,12 +6,17 @@
     "Brady Vitrano <brady.vitrano@rackspace.com>"
   ],
   "scripts": {
-    "test": "grunt test",
-    "build": "bundle install && npm install && bower install"
+    "test": "npm run grunt test",
+    "postinstall": "bundle install && npm run bower install",
+    "build": "npm run grunt build",
+    "server": "cd docs && jekyll server",
+    "bower": "./node_modules/bower/bin/bower ",
+    "grunt": "./node_modules/grunt-cli/bin/grunt "
   },
-  "repository": "coming soon",
+  "repository": "https://github.com/rackerlabs/zoolander",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
+    "bower": "^1.6.5",
     "grunt": "^0.4.5",
     "grunt-concurrent": "*",
     "grunt-contrib-concat": "*",
@@ -26,11 +31,7 @@
     "grunt-webpack": "^1.0.11",
     "load-grunt-config": "*",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
-  },
-  "dependencies": {
-    "bootstrap": "^3.3.5",
-    "jquery": "^2.1.4",
+    "webpack-dev-server": "^1.12.0",
     "time-grunt": "*"
   }
 }


### PR DESCRIPTION
This PR adds a few convenience `npm` commands and leverages local installs for `grunt` and `bower`.