### PR TITLE
chore(package.json): Add "harp:compile" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "harp": "harp ",
+    "harp:compile": "npm run harp compile styleguide dist",
     "start": "harp server styleguide",
     "gh-pages": "./build-pages.sh",
     "preversion": "npm run harp compile styleguide dist && git add .",


### PR DESCRIPTION
Adds a harp:compile option to package.json to allow for zoolander compilation, with out adding to git repo. 