### PR TITLE
RSWEB-6329: Convert tertiary menu triggers from anchors to spans.

### DIFF
--- a/styleguide/_themes/derek/scss/components/mainnav.scss
+++ b/styleguide/_themes/derek/scss/components/mainnav.scss
@@ -57,6 +57,7 @@
 }
 
 .navbar-dropDown-trigger {
+  display: block;
 
   &::after {
     content: '\f0da';

--- a/styleguide/derek/_partials/_mainnav.ejs
+++ b/styleguide/derek/_partials/_mainnav.ejs
@@ -18,7 +18,7 @@
                 <ul class="dropdown-menu navbar-dropDownMenu">
                   <li class="navbar-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Public Cloud</a></li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger">Private Cloud</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Private Cloud</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">VMware vCloud®</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">OpenStack</a></li>
@@ -36,7 +36,7 @@
                 <ul class="dropdown-menu navbar-dropDownMenu">
                   <li class="navbar-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Dedicated Hosting</a></li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger active">Compute</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Compute</a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" column="0" class="navbar-dropDownLink">Virtual Cloud Servers</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">OnMetal Cloud Servers</a></li>
@@ -46,7 +46,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger active">Network </a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Network </a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Networks</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Load Balancers</a></li>
@@ -56,7 +56,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger active">Storage</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Storage</a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Block Storage</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Backup </a></li>
@@ -66,7 +66,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger active">Infrastructure &amp; Developer Tools</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Infrastructure &amp; Developer Tools</a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Orchestration</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Auto Scale</a></li>
@@ -76,7 +76,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger active">Database &amp; Data Analytics </a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Database &amp; Data Analytics </a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Cloud Databases</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Managed Cloud Big Data</a></li>
@@ -85,7 +85,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="javascript:void(0)" class="navbar-dropDownLink navbar-dropDown-trigger">Email Hosting</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Email Hosting</a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Office 365</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Exchange Solutions</a></li>
@@ -97,7 +97,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <a href="/productivity-collaboration" class="navbar-dropDownLink navbar-dropDown-trigger">Productivity and Collaboration</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Productivity and Collaboration</a>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Office 365</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Sharepoint</a></li>


### PR DESCRIPTION
This PR converts the tertiary triggers to `<span>` tags from `<a>` tags.  This was done in #163 for top-level nav, but got overlooked in the tertiary triggers. 