### PR TITLE
style(zoolander):h1-swap

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/lead.scss
+++ b/styleguide/_themes/derek/scss/patterns/lead.scss
@@ -1,0 +1,21 @@
+.lead-row {
+  @import make-row;
+}
+
+.lead-container {
+  @import make-md-column(10);
+  @import make-md-column-push(1);
+}
+
+.lead-title {
+  text-align: $center;
+}
+
+.lead-text {
+  text-align: $center;
+}
+
+//to support legacy
+.lead {
+  text-align: $center;
+}

--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -24,3 +24,34 @@
     background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/backgrounds/o365-overview.jpg');
   }
 }
+
+.banner-headline {
+  @include heading($white);
+  font-size: 3em;
+  line-height: 1em;
+  text-align: center;
+}
+
+
+.imacBanner-container {
+  background-color: $brand-primary;
+  color: $white;
+
+  &.large {
+    height: 300px;
+    padding-top: 30px;
+  }
+}
+
+.imacBanner-headline {
+  @include heading($white);
+  font-size: 4rem;
+  font-weight: 700;
+  line-height: 3.75rem;
+  margin: 0;
+}
+
+.imacBanner-text {
+  border: 3px solid $white;
+  padding: 15px;
+}

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -35,13 +35,13 @@ p {
 
 h1 {
   @include heading;
-  font-size: 3em;
+  font-size: 2.25em;
   text-align: center;
 }
 
 h2 {
   @include heading;
-  font-size: 2em;
+  font-size: 1.75em;
   line-height: 1.25em;
 }
 
@@ -102,11 +102,11 @@ ul {
   }
 }
 
-.checks li::before{
+.checks li::before {
   content: '\f00c';
 }
 
-.times li::before{
+.times li::before {
   content: '\f00d';
 }
 

--- a/styleguide/_themes/global/scss/global.scss
+++ b/styleguide/_themes/global/scss/global.scss
@@ -11,3 +11,9 @@
 @import 'buttons';
 @import 'banners';
 @import 'bootstrap_overrides';
+
+@media screen and (min-width: $screen-md-min) {
+  .container {
+    width: 960px;
+  }
+}

--- a/styleguide/derek/_partials/solutions/header-large.ejs
+++ b/styleguide/derek/_partials/solutions/header-large.ejs
@@ -1,16 +1,19 @@
 <!--Header Large-->
-<div class="container-fluid banner large outlook">
-  <div class="row">
-    <div class="col-sm-5 center-block">
-      <div class="banner-text">
-        <h1 class="center white">Fanatical Support for Office 365</h1>
-        <p class="center white">All the power of Office 365. None of the frustration and management. We help you get the most out of Office 365.</p>
+<div class="banner large outlook">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-5 center-block">
+        <div class="banner-text">
+          <!--NEED TO SWITCH THE CLASS IN DRUPAL PATTERN FOR H2-->
+          <h2 class="banner-headline">Fanatical Support for Office 365</h2>
+          <p class="center white">All the power of Office 365. None of the frustration and management. We help you get the most out of Office 365.</p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-4 center-block center">
-      <a class="button learning">Choose A Plan</a>
+    <div class="row">
+      <div class="col-sm-4 center-block center">
+        <a class="button learning">Choose A Plan</a>
+      </div>
     </div>
   </div>
 </div>

--- a/styleguide/derek/_partials/solutions/header-largeIMAC.ejs
+++ b/styleguide/derek/_partials/solutions/header-largeIMAC.ejs
@@ -1,0 +1,18 @@
+<!--Header Large-->
+<div class="imacBanner-container large">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-7">
+        <div class="imacBanner-text">
+          <h2 class="imacBanner-headline">3,000 cloud experts working for you 24/7/365?<br/>
+          Sounds like you may need a bigger office.</h2>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-4">
+        <a class="button banner">Choose A Plan</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/styleguide/derek/_partials/solutions/header-medium.ejs
+++ b/styleguide/derek/_partials/solutions/header-medium.ejs
@@ -1,10 +1,13 @@
 <!--Header Medium-->
-<div class="container-fluid banner medium outlook">
-  <div class="row">
-    <div class="col-sm-6 center-block">
-      <div class="banner-text">
-        <h1 class="center white">Pick Your Plan</h1>
-        <p class="center white">Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do.</p>
+<div class="banner medium outlook">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-6 center-block">
+        <div class="banner-text">
+          <!--NEED TO SWITCH THE CLASS IN DRUPAL PATTERN FOR H2-->
+          <h2 class="banner-headline">Pick Your Plan</h2>
+          <p class="center white">Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/styleguide/derek/_partials/solutions/lead.ejs
+++ b/styleguide/derek/_partials/solutions/lead.ejs
@@ -2,10 +2,10 @@
 <div class="container">
   <h4>Lead</h4>
   <p>Limit to one paragraph</p>
-  <div class="row">
-    <div class="col-md-10 center-block">
-      <h2 class="center">Title goes here</h2>
-      <p class="center">Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do. T-bone meatloaf chuck prosciutto biltong. Eu jowl pariatur id, ut pork belly aliquip ipsum shoulder swine est. In dolor qui pastrami, proident velit laborum prosciutto shoulder. Cow in cillum, dolor kielbasa ut occaecat aute irure.</p>
+  <div class="lead-row">
+    <div class="lead-container">
+      <h1 class="lead-title">Title goes here</h1>
+      <p class="lead lead-text">Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do. T-bone meatloaf chuck prosciutto biltong. Eu jowl pariatur id, ut pork belly aliquip ipsum shoulder swine est. In dolor qui pastrami, proident velit laborum prosciutto shoulder. Cow in cillum, dolor kielbasa ut occaecat aute irure.</p>
     </div>
   </div>
 </div>

--- a/styleguide/derek/_partials/typography/heading.ejs
+++ b/styleguide/derek/_partials/typography/heading.ejs
@@ -1,6 +1,6 @@
 <div class="col-md-12 half-padding-top">
   <h1>Page Title</h1>
-  <p>h1. <code>font-size: 3em;</code> For use in hero/banner areas only.</p>
+  <p>h1. <code>font-size: 3em;</code> For use in lead areas only.</p>
 </div>
 <div class="col-md-12 half-padding-top">
   <h2>River heading</h2>

--- a/styleguide/derek/assets/_layout.jade
+++ b/styleguide/derek/assets/_layout.jade
@@ -1,4 +1,4 @@
-extends ../../_layouts/default
+extends ../../_layouts/page
 
 block content
   != yield

--- a/styleguide/derek/assets/photography.jade
+++ b/styleguide/derek/assets/photography.jade
@@ -60,11 +60,23 @@
       h5 Medium Banner
       p This banner type should be used on product overview pages. No CTA is included but it has a larger image area as well as text area.
       p Headline should be limited to 2 - 4 words. Text area to 140 characters.
-      include ../_partials/solutions/header-medium.ejs
 
+include ../_partials/solutions/header-medium.ejs
+
+.container
   .row.half-padding-full
     .col-md-12
       h5 Large Banner
       p This banner type should be used on section overview pages or landing pages. A CTA is included within this section as well as a much larger image area.
       p Headline should be limited to 3 - 6 words. Text area to 140 characters and CTA to 3 words or less.
-      include ../_partials/solutions/header-large.ejs
+
+include ../_partials/solutions/header-large.ejs
+
+.container
+  .row.half-padding-full
+    .col-md-12
+      h5 Large IMAC Banner
+      p This banner type should be used on section overview pages or landing pages for the IMAC campaign. A CTA is included within this section as well as a much larger image area.
+      p Headline should be limited to 3 - 6 words. Text area to 140 characters and CTA to 3 words or less.
+
+include ../_partials/solutions/header-largeIMAC.ejs


### PR DESCRIPTION
https://jira.rax.io/browse/RSWEB-6940
Switches h1 to lead position and h2 to banner position. Need to switch h2 class for our drupal pattern banners to banner-headline, to avoid the h2 resizing issue, since h2 is our designated river title size.

View title in banner cases here:
http://localhost:9000/derek/assets/photography

typography cases here: 
http://localhost:9000/derek/assets/typography

and the lead/heading changes here:
http://localhost:9000/derek/examples/solutions