### PR TITLE
RSWEB-7241: equal height fix to resource class

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/grid/businessResource.scss
+++ b/styleguide/_themes/derek/scss/patterns/grid/businessResource.scss
@@ -49,3 +49,7 @@
   @include make-sm-column(6);
   @include flex-box;
 }
+
+.resource {
+  @include flex-box;
+}


### PR DESCRIPTION
Updates resource class to ```display: flex;``` so that background will extend full height of the row. 