### PR TITLE
RSWEB-7205: focus state color should not change in footer links

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/footer.scss
+++ b/styleguide/_themes/derek/scss/globalElements/footer.scss
@@ -18,9 +18,13 @@
   font-size: 1.2rem;
   text-decoration: none;
 
+  &:focus {
+    text-decoration: none;
+  }
+
+  &:focus,
   &:hover {
     color: $gray-light;
-    text-decoration: underline;
   }
 }
 

--- a/styleguide/_themes/global/scss/bootstrap_overrides.scss
+++ b/styleguide/_themes/global/scss/bootstrap_overrides.scss
@@ -22,15 +22,30 @@
   color: $white;
 }
 
-// Footer
-.panel-default > .panel-heading + .panel-collapse > .panel-body {
-  border: 0;
-}
-
 // Navs
 .nav > li > a:focus {
   background-color: transparent;
 }
 .nav > li.no-hover > a:focus {
   background-color: $brand-success;
+}
+
+// Footer
+.footer {
+  li {
+    a {
+      &:focus {
+        color: $gray-light;
+        text-decoration: none;
+      }
+
+      &.active {
+        color: $gray-light;
+      }
+    }
+  }
+}
+
+.panel-default > .panel-heading + .panel-collapse > .panel-body {
+  border: 0;
 }


### PR DESCRIPTION
Changes the focus state to be the original link color and removes the underline. Also removes the change to black for the active state in the footer.

Can be seen here http://localhost:9000/derek/examples/events