### PR TITLE
RSWEB-7209: remove border bottom in tablet

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -323,7 +323,6 @@
   }
 
   .navbar-container {
-    border-bottom: 1px solid $gray-dark;
     max-width: $screen-md;
   }
 }


### PR DESCRIPTION
Removes ```border-bottom: 1px solid #333; ``` from the ```navbar-container``` class for screen @ max-width: 991px.

Navigate to http://localhost:9000/derek/examples/section-overview in zoolander and set screen to width between 768px and 991px. The border lines should not appear when the Search is expanded.