### PR TITLE
RSWEB-7046: multiple global nav improvements

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -145,12 +145,6 @@
 
 .navbar-dropDownSub {
   position: relative;
-
-  &:hover {
-    .navbar-dropDownMenu {
-      display: block;
-    }
-  }
 }
 
 .navbar-dropDownSub > .navbar-dropDown-trigger {
@@ -287,15 +281,19 @@
   }
 }
 
-//main nav show dropdowns on hover on desktop
+//main nav on desktop
 @media only screen and (min-width: $screen-md-min) {
-  .dropdown {
+  .dropdown-toggle {
 
-    &:hover {
-      .navbar-dropDownMenu {
-        display: block;
-      }
+    &::after {
+      content: '\f0d7';
+      font-family: 'FontAwesome';
+      margin-left: 10px;
     }
+  }
+
+  .navbar-dropDown-triggerActive {
+    background-color: $gray;
   }
 }
 
@@ -318,7 +316,7 @@
     }
 
     .navbar-topLink {
-      padding: 21px 9px;
+      padding: 21px 8px;
     }
   }
 
@@ -332,6 +330,15 @@
   .navbar-menu {
     float: left;
     margin-left: 10px;
+  }
+
+  .dropdown-toggle {
+
+    &::after {
+      content: '\f0d7';
+      font-family: 'FontAwesome';
+      margin-left: 3px;
+    }
   }
 
   .navbar-dropDown-trigger {
@@ -364,11 +371,37 @@
     }
   }
 
+  .dropdown-toggle {
+
+    &::after {
+      content: '\f0da';
+      font-family: FontAwesome;
+      margin-left: 10px;
+    }
+  }
+
+  .navbar-dropDown-triggerActive {
+    background-color: $gray-darker;
+    display: block;
+
+    &::after {
+      content: '\f0d7';
+      top: 6px;
+    }
+  }
+
   .navbar-nav {
     margin: 0 0 7.5px;
 
     .navbar-topItem {
-      font-size: 1rem;
+      font-size: 1.45rem;
+
+      .navbar-dropDownLink,
+      .navbar-dropDownLabel,
+      .navbar-tertiary-dropDownLink {
+        border-bottom: 1px solid $gray-darker;
+        font-size: 1.45rem;
+      }
 
       .navbar-dropDownMenu {
         background: $gray-dark;

--- a/styleguide/_themes/global/scss/bootstrap_overrides.scss
+++ b/styleguide/_themes/global/scss/bootstrap_overrides.scss
@@ -26,6 +26,7 @@
 .nav > li > a:focus {
   background-color: transparent;
 }
+
 .nav > li.no-hover > a:focus {
   background-color: $brand-success;
 }
@@ -48,4 +49,14 @@
 
 .panel-default > .panel-heading + .panel-collapse > .panel-body {
   border: 0;
+}
+
+@media screen and (max-width: $screen-sm-max) {
+
+  .navbar-dropDownMenu > li.navbar-dropDownItem > .navbar-dropDown-triggerActive {
+    &:focus,
+    &:hover {
+      background-color: $gray-darker;
+    }
+  }
 }

--- a/styleguide/derek/_partials/_mainnav.ejs
+++ b/styleguide/derek/_partials/_mainnav.ejs
@@ -36,7 +36,7 @@
                 <ul class="dropdown-menu navbar-dropDownMenu">
                   <li class="navbar-dropDownItem"><a href="javascript:void(0)" class="navbar-dropDownLink">Dedicated Hosting</a></li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Compute</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Compute</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Virtual Cloud Servers</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">OnMetal Cloud Servers</a></li>
@@ -46,7 +46,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Network </a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Network</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Networks</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Load Balancers</a></li>
@@ -56,7 +56,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Storage</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Storage</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Block Storage</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Backup </a></li>
@@ -66,7 +66,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Infrastructure &amp; Developer Tools</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Infrastructure &amp; Developer Tools</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Orchestration</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Auto Scale</a></li>
@@ -76,7 +76,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Database &amp; Data Analytics </a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger active">Database &amp; Data Analytics</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Cloud Databases</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Managed Cloud Big Data</a></li>
@@ -85,7 +85,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Email Hosting</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Email Hosting</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Office 365</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Exchange Solutions</a></li>
@@ -97,7 +97,7 @@
                     </ul>
                   </li>
                   <li class="navbar-dropDownItem navbar-tertiary-dropDownTrigger">
-                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Productivity and Collaboration</a>
+                    <span class="navbar-dropDownLink navbar-dropDown-trigger">Productivity and Collaboration</span>
                     <ul class="dropdown-menu navbar-dropDownMenu navbar-tertiary-dropDownMenu">
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Office 365</a></li>
                       <li class="navbar-tertiary-dropDownItem"><a href="javascript:void(0)" class="navbar-tertiary-dropDownLink">Sharepoint</a></li>

--- a/styleguide/js/zoolander.js
+++ b/styleguide/js/zoolander.js
@@ -1,52 +1,84 @@
 jQuery(document).ready(function($) {
   //main nav functionality
+  var $topLevelDropDown = $('.navbar-topItem > .dropdown-toggle');
+  var $navBurger = $(".navbar-hamburger");
+
   jQuery ("#search,#searchDesktop").click(function(){
     $(".navbar-search").slideToggle();
     $(".navbar-activeArrow").fadeToggle();
     $(".navbar-menuContainer").removeClass("in");
-    $(".navbar-hamburger").addClass("collapsed");
+    $navBurger.addClass("collapsed");
   });
+
   jQuery (".navbar-searchInput").click(function(){
     $(".navbar-searchButton").css('opacity', 1);
-  })
-  jQuery (".navbar-hamburger").click(function(){
-    $(".navbar-hamburger").toggleClass("collapsed");
+  });
+
+  $navBurger.click(function(){
+    $navBurger.toggleClass("collapsed");
     $(".navbar-search").slideUp();
     $(".navbar-activeArrow").fadeOut();
-  })
+
+    //reset dopdown carrets if collapsing the menu
+    if($(this).hasClass('collapsed')){
+      $topLevelDropDown.removeClass('navbar-dropDown-triggerActive');
+    }
+  });
+
+  //Toggle the open arrows on, top level, non drop down links
+  $('.navbar-topLink:not(.navbar-topLink.dropdown-toggle)').click(function(){
+    var $el = $(this).parent();
+    $el.siblings().find('.navbar-dropDown-triggerActive').removeClass('navbar-dropDown-triggerActive');
+    $el.siblings().find('.navbar-tertiary-dropDownMenu').hide();
+  });
+
+  //Toggle arrows for top level drop down links
+  $topLevelDropDown.click(function(){
+    var $el = $(this);
+    $el.toggleClass('navbar-dropDown-triggerActive');
+    $el.parent().siblings().find('.dropdown-toggle').removeClass('navbar-dropDown-triggerActive');
+  });
 
   // Special mobile functionality.
   var isMainNavScrolling = false;
-  var dropDownTrigger = function (e) {
+  var dropDownTrigger = function (trigger) {
     if (!isMainNavScrolling) {
-      var $current = $(this).find('.navbar-tertiary-dropDownMenu');
-      var $siblings = $(this).siblings('.navbar-tertiary-dropDownTrigger').find('.navbar-tertiary-dropDownMenu');
+      var $el = trigger;
+      var $current = $el.find('.navbar-tertiary-dropDownMenu');
+      var $siblings = $el.siblings('.navbar-tertiary-dropDownTrigger').find('.navbar-tertiary-dropDownMenu');
+      $el.find('.navbar-dropDownLink').toggleClass('navbar-dropDown-triggerActive');
+      //remove siblings open arrows
+      $el.siblings('.navbar-tertiary-dropDownTrigger').find('.navbar-dropDownLink').removeClass('navbar-dropDown-triggerActive');
+
       $current.toggle();
       $siblings.hide();
-      e.preventDefault();
     }
   };
 
-  if (Modernizr.touch) {
-    // Fix for known bootstrap scroll height bug: https://github.com/twbs/bootstrap/issues/12738
-    var fixScrollBug = function() {
-      $(".navbar-collapse").css({maxHeight: $(window).height() - $(".navbar-header").height() + "px"});
-    };
-    fixScrollBug();
-    window.addEventListener("resize", fixScrollBug);
-    $('.navbar-tertiary-dropDownLink').on('touchstart touchend', function(e) {
+  // Indicate whether or not we're currently scrolling, or tapping on a link.
+  // Fix for known bootstrap scroll height bug: https://github.com/twbs/bootstrap/issues/12738
+  var fixScrollBug = function() {
+    $(".navbar-collapse").css({maxHeight: $(window).height() - $(".navbar-header").height() + "px"});
+  };
+  fixScrollBug();
+  window.addEventListener("resize", fixScrollBug);
+
+  //set the trigger to show drop downs on hover or clicks depending on viewport
+  var $viewPort;
+  $(".navbar-tertiary-dropDownTrigger")
+    .click(function(e){
       e.stopPropagation();
+      $viewPort = parseInt($(window).outerWidth());
+      if ($viewPort < 768){
+        dropDownTrigger($(this));
+      }
+    })
+    .hover(function(){
+      $viewPort = parseInt($(window).outerWidth());
+      if ($viewPort > 768){
+        dropDownTrigger($(this));
+      }
     });
-    // Indicate whether or not we're currently scrolling, or tapping on a link.
-    $(".navbar-tertiary-dropDownTrigger")
-        .on('touchstart', function (e) { isMainNavScrolling = false; })
-        .on('touchmove', function (e) { isMainNavScrolling = true; })
-        .on('touchend', dropDownTrigger);
-  } else {
-    $(".navbar-tertiary-dropDownTrigger")
-      .hover(dropDownTrigger)
-      .on('click', function (e) { e.stopPropagation(); });
-  }
 
   //back to top
   var offset = 250;


### PR DESCRIPTION
Things Done:
1.) Added down carots to desktop dropdown buttons, and right carots to mobile.
2.) Added toggle functionality for arrows on mobile when open/close 
3.) Added subtle bottom border to drop down links in mobile for differentiation purposes.
4.) Set a larger font size to all nav links in mobile.
I also switched our drop down trigger to 'clicks' instead of 'hovering' for a more consistent UX. This may still be up for debate. This also helps in developing for mobile/desktop as right now we're competing against the different listeners.

![screen shot 2016-09-02 at 2 13 36 pm](https://cloud.githubusercontent.com/assets/4554644/18215742/4c481e18-7118-11e6-9f8a-91503a690707.png)
![screen shot 2016-09-02 at 2 13 56 pm](https://cloud.githubusercontent.com/assets/4554644/18215743/4df20332-7118-11e6-99d0-906d323f16b0.png)
![screen shot 2016-09-02 at 2 14 07 pm](https://cloud.githubusercontent.com/assets/4554644/18215746/5136a0d4-7118-11e6-8d03-b624e09a223f.png)
