### PR TITLE
RSWEB-7033: Adjust announcements for www-readiness.

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/announcements.scss
+++ b/styleguide/_themes/derek/scss/patterns/announcements.scss
@@ -1,65 +1,52 @@
-.announcement-container {
+.announcement-wrapper {
   background-color: $white;
   border-bottom: 1px solid $gray-light;
   border-right: 1px solid $gray-light;
   border-top: 1px solid $gray-light;
   margin-bottom: 10px;
   overflow: hidden;
-  padding: 10px;
-  position: relative;
-  width: $full-width;
+  padding: 10px 0;
 }
 
 .announcement-icon {
   @include make-md-column(2);
+  @include flex-box;
+  font-size: 5rem;
+
+  .fa {
+    color: $gray-base;
+  }
 }
 
 .announcement-message {
   @include make-md-column(10);
+  @include flex-box;
   padding-top: 12px;
 }
 
-.announcement-close {
-  height: 10px;
-  position: absolute;
-  right: 8px;
-  text-decoration: none;
-  top: 8px;
-  width: 10px;
-  z-index: 5;
-
-  &::before {
-    content: '\f00d';
-    font-family: FontAwesome;
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-//Offer announcements
-.announcement-offer {
-  border-left: 8px solid $brand-secondary;
-}
-
-//Warning announcements
-.announcement-warning {
-  border-left: 8px solid $brand-warning;
-}
-
-//Danger announcements
-.announcement-danger {
+//Alert announcements
+.announcement-alert {
   border-left: 8px solid $brand-danger;
 }
 
-//Success announcements
-.announcement-success {
+//General announcements
+.announcement-general {
+  border-left: 8px solid $brand-warning;
+}
+
+//New Product announcements
+.announcement-newProduct {
+  border-left: 8px solid $brand-secondary;
+}
+
+//Promotion announcements
+.announcement-promotion {
   border-left: 8px solid $brand-success;
 }
 
 @media only screen and (max-width: $screen-xs-max) {
-  .announcement-icon {
+  .announcement-icon,
+  .announcement-message {
     width: $full-width;
   }
 }

--- a/styleguide/_themes/derek/scss/patterns/announcements.scss
+++ b/styleguide/_themes/derek/scss/patterns/announcements.scss
@@ -21,7 +21,7 @@
 .announcement-message {
   @include make-md-column(10);
   @include flex-box;
-  padding-top: 12px;
+  padding: 12px 15px;
 }
 
 //Alert announcements

--- a/styleguide/_themes/derek/scss/patterns/subpanels.scss
+++ b/styleguide/_themes/derek/scss/patterns/subpanels.scss
@@ -3,6 +3,16 @@
   .lead-title  {
     text-align: left;
   }
+
+  // Announcements in subpanels should mimic mobile mode.
+  .announcement-icon,
+  .announcement-message {
+    width: $full-width;
+  }
+
+  .announcement-wrapper {
+    display: block;
+  }
 }
 
 .subpanelWell {

--- a/styleguide/derek/_partials/solutions/announcements.ejs
+++ b/styleguide/derek/_partials/solutions/announcements.ejs
@@ -1,64 +1,18 @@
-<div class="standard-padding bg-light-gray">
-  <div class="container">
-
-    <div class="row">
-      <div class="center-block">
-        <h2 class="center teal">Announcements</h2>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="alert announcement-container announcement-offer fade in row-eq-height">
-        <a href="#" data-dismiss="alert" class="announcement-close"></a>
-        <div class="announcement-icon flex-center-all"><i class="rsweb idio-piggy"></div>
-        <div class="announcement-message">
-          <p>Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="alert announcement-container announcement-warning fade in row-eq-height">
-        <a href="#" data-dismiss="alert" class="announcement-close"></a>
-        <div class="announcement-icon flex-center-all"><i class="rsweb idio-piggy"></div>
-        <div class="announcement-message">
-          <p>Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum.
-          Suscipit porta, enim id metus dicta ultrices, id orci urna, adipiscing
-          lectus mattis. Tristique nibh et, consectetuer faucibus cras nec mollis
-          vehicula etiam, sit eu luctus facilisi tincidunt a.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="alert announcement-container announcement-danger fade in row-eq-height">
-        <a href="#" data-dismiss="alert" class="announcement-close"></a>
-        <div class="announcement-icon flex-center-all"><i class="rsweb idio-piggy"></div>
-        <div class="announcement-message">
-          <p>Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum.
-          Suscipit porta, enim id metus dicta ultrices, id orci urna, adipiscing
-          lectus mattis. Tristique nibh et, consectetuer faucibus cras nec mollis
-          vehicula etiam, sit eu luctus facilisi tincidunt a.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="alert announcement-container announcement-success fade in row-eq-height">
-        <a href="#" data-dismiss="alert" class="announcement-close"></a>
-        <div class="announcement-icon flex-center-all"><i class="rsweb idio-piggy"></div>
-        <div class="announcement-message">
-          <p>Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum.
-          Suscipit porta, enim id metus dicta ultrices, id orci urna, adipiscing
-          lectus mattis. Tristique nibh et, consectetuer faucibus cras nec mollis
-          vehicula etiam, sit eu luctus facilisi tincidunt a.</p>
-          <p>Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum.
-          Suscipit porta, enim id metus dicta ultrices, id orci urna, adipiscing
-          lectus mattis. Tristique nibh et, consectetuer faucibus cras nec mollis
-          vehicula etiam, sit eu luctus facilisi tincidunt a.</p>
-        </div>
-      </div>
-    </div>
-
+<!-- Default description to allow for partial override to demonstrate really long text and equal height -->
+<%
+if(!desc) { var desc = "Lorem ipsum dolor sit amet, cum cras lectus consectetuer dictum. Suscipit porta, enim id metus dicta ultrices, id orci urna, adipiscing lectus mattis. Tristique nibh et, consectetuer faucibus cras nec mollis vehicula etiam, sit eu luctus facilisi tincidunt a."; }
+if(!type) { var type = 'general'; }
+var icons = {
+  'alert' : 'fa-exclamation-circle',
+  'general' : 'fa-bullhorn',
+  'newProduct' : 'fa-server',
+  'promotion' : 'fa-money'
+};
+%>
+<div class="announcement-wrapper announcement-<%- type %> fade in row-eq-height">
+  <div class="announcement-icon flex-center-all"><i class="fa <%- icons[type] %>" aria-hidden="true"></i></div>
+  <div class="announcement-message">
+    <p><%- desc %></p>
   </div>
 </div>
+

--- a/styleguide/derek/_partials/solutions/announcements.ejs
+++ b/styleguide/derek/_partials/solutions/announcements.ejs
@@ -12,7 +12,7 @@ var icons = {
 <div class="announcement-wrapper announcement-<%- type %> fade in row-eq-height">
   <div class="announcement-icon flex-center-all"><i class="fa <%- icons[type] %>" aria-hidden="true"></i></div>
   <div class="announcement-message">
-    <p><%- desc %></p>
+    <%- desc %>
   </div>
 </div>
 

--- a/styleguide/derek/examples/solutions.ejs
+++ b/styleguide/derek/examples/solutions.ejs
@@ -20,10 +20,15 @@
   </div>
 </div>
 
+<!-- Lead -->
 <div class="container">
-  <h4>Text</h4>
+  <h4>Lead</h4>
   <p>Limit to one paragraph</p>
-  <%- partial('../_partials/solutions/lead.ejs') %>
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/lead.ejs') %>
+    </div>
+  </div>
 </div>
 
 <%- partial('../_partials/solutions/key-offers.ejs') %>
@@ -31,6 +36,7 @@
 <%- partial('../_partials/solutions/customer-stories.ejs') %>
 <%- partial('../_partials/solutions/services-3-col.ejs') %>
 
+<!-- Video -->
 <div class="container">
   <h4>Video</h4>
   <div class="videoEmbed-row">
@@ -48,10 +54,56 @@
 <%- partial('../_partials/solutions/tabs.ejs') %>
 <%- partial('../_partials/solutions/features.ejs') %>
 <%- partial('../_partials/solutions/lists.ejs') %>
-<%- partial('../_partials/solutions/announcements.ejs') %>
+
+<!-- Announcements -->
+<div class="container">
+  <h4>Announcements</h4>
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/announcements.ejs', {
+        'type': 'newProduct',
+        'desc': 'This is a New Product. Vivamus quis sem sollicitudin, cursus tellus eget, tempor ex. Suspendisse ut magna condimentum, blandit sem vel, auctor urna. Aenean eu auctor erat. '
+      }) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/announcements.ejs', {
+        'type': 'alert',
+        'desc': 'This is an Alert. Vivamus quis sem sollicitudin, cursus tellus eget, tempor ex. Suspendisse ut magna condimentum, blandit sem vel, auctor urna. Aenean eu auctor erat. Aliquam lobortis posuere porta. In nec sagittis dolor. Proin et augue fringilla, aliquet mauris quis, pretium quam. Vestibulum leo turpis, porttitor et ipsum sit amet, porta gravida nibh.'
+      }) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/announcements.ejs', {
+        'type': 'general',
+        'desc': 'This is a General Announcement. Vivamus quis sem sollicitudin, cursus tellus eget, tempor ex. Suspendisse ut magna condimentum, blandit sem vel, auctor urna. Aenean eu auctor erat. Aliquam lobortis posuere porta. In nec sagittis dolor. Proin et augue fringilla, aliquet mauris quis, pretium quam. Vestibulum leo turpis, porttitor et ipsum sit amet, porta gravida nibh.'
+      }) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/announcements.ejs', {
+        'type': 'promotion',
+        'desc': 'This is a Promotion. Vivamus quis sem sollicitudin, cursus tellus eget, tempor ex. Suspendisse ut magna condimentum, blandit sem vel, auctor urna. Aenean eu auctor erat. Aliquam lobortis posuere porta. In nec sagittis dolor. Proin et augue fringilla, aliquet mauris quis, pretium quam. Vestibulum leo turpis, porttitor et ipsum sit amet, porta gravida nibh.'
+      }) %>
+    </div>
+  </div>
+</div>
+</div>
+
 <%- partial('../_partials/solutions/blog-feed.ejs') %>
 
+<!-- Text -->
 <div class="container">
   <h4>Text</h4>
-  <%- partial('../_partials/solutions/text.ejs') %>
+  <div class="row">
+    <div class="col-xs-12">
+      <%- partial('../_partials/solutions/text.ejs') %>
+    </div>
+  </div>
 </div>

--- a/styleguide/derek/examples/subpanels.ejs
+++ b/styleguide/derek/examples/subpanels.ejs
@@ -15,6 +15,7 @@ var layouts = {
 
 // List of available patterns sorted by title.
 var patterns = {
+  'announcements': {'title' : 'Announcement'},
   'lead': {'title': 'Lead'},
   'text': {'title': 'Text'},
   'video': {'title' : 'Video'}


### PR DESCRIPTION
This PR makes the following changes to the announcement pattern, in preparation for being integrated into www: 

1. Renamed `announcement-container` to `announcement-wrapper` to avoid confusion with bootstrap containers.
2. Removed left/right padding
3. Since we have to use FontAwesome until new icons are ready, I made a few updates to the icon class. 
4. Renamed announcent type classes, to be more indicative of what they actually are supposed to be.
5. Set subpanels version of announcement to mimic mobile experience.
6. Setup type-specific icons.
7. Pull all non-essential code out of the announcement partial
