### PR TITLE
RSWEB-7110: Added basic compare tables pattern

### DIFF
--- a/styleguide/_themes/global/scss/tables.scss
+++ b/styleguide/_themes/global/scss/tables.scss
@@ -28,7 +28,10 @@ $table-padding: 20px 5px;
 }
 
 .productTable-featureItem {
-  &::before {
+  padding: 20px;
+  vertical-align: text-top;
+
+  &::after {
     @include center-block;
     font-family: FontAwesome;
     padding: 10px 0;
@@ -37,20 +40,28 @@ $table-padding: 20px 5px;
 }
 
 .offered {
-  &::before {
+  vertical-align: inherit;
+
+  &::after {
     color: $teal-dark;
     content: '\f00c';
   }
 }
 
 .notOffered {
-  &::before {
+  vertical-align: inherit;
+
+  &::after {
     color: $gray-lighter;
     content: '\f00d';
   }
 }
 
-@media screen and (max-width: 768px) {
+.productTable-mobileTitle {
+  display: none;
+}
+
+@media screen and (max-width: $screen-xs-max) {
   .productTable {
     display: flex;
     flex-flow: column;
@@ -59,9 +70,11 @@ $table-padding: 20px 5px;
   }
 
   .productTable-row {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-around;
+    display: block;
+  }
+
+  .productTable-header {
+    display: none;
   }
 
   .productTable-name {
@@ -82,29 +95,25 @@ $table-padding: 20px 5px;
 
   .productTable-feature,
   .productTable-featureItem {
-    display: flex;
-    flex-flow: row;
-    flex-grow: 1;
-    justify-content: center;
+    display: block;
 
     :first-child {
-      background: $gray-lighter;
+      background: $gray-lightest;
       display: block;
       width: 100%;
     }
   }
 
-  .horizontal-scroll {
+  .productTable-featureItem {
+    padding: 8px;
+
+    &::after {
+      display: inline-block;
+      margin-left: 15px;
+    }
+  }
+
+  .productTable-mobileTitle  {
     display: block;
-
-    .productTable-row {
-      display: table-row;
-    }
-
-    .productTable-name,
-    .productTable-featureItem {
-      display: table-cell;
-      padding: 10px;
-    }
   }
 }

--- a/styleguide/derek/examples/tables.ejs
+++ b/styleguide/derek/examples/tables.ejs
@@ -47,7 +47,7 @@
   <h4>Database Servers</h4>
   <p>This table should be used for tables too large to work in the responsive table layout. It simply adds a wrapping class of table-responsive (which is a bootstrap helper class) and then the table itself gets a class of horizontal scroll. This allows the table to scroll to the left without breaking the page.</p>
   <div class="table-responsive">
-    <table class="productTable horizontal-scroll">
+    <table class="productTable">
       <thead class="productTable-header">
         <tr class="productTable-row">
           <th class="productTable-name"></th>
@@ -152,4 +152,125 @@
   </table>
 </div>
 
-
+<div class="container half-padding-full">
+  <h4>Navigator / Aviator</h4>
+  <table class="productTable">
+    <thead class="productTable-header">
+      <tr class="productTable-row">
+        <th class="productTable-name">Human Experts</th>
+        <th class="productTable-name">Navigator</th>
+        <th class="productTable-name">Aviator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Technical Account Manager (TAM)</strong>
+          <ul>
+            <li>Personal contact for ongoing business and technical assistance</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem offered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Support of the AWS platform</strong>
+          <ul>
+            <li>100% certified AWS engineers deliver Fanatical Support for AWS 24x7x365</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem offered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">PCI and HIPPA Compliance</strong>
+          <ul>
+            <li>Certified Level 1 Payment Card Industry (PCI) Service Provider on AWS</li>
+            <li>We can act as a business associate to support customers with HIPAA workloads on AWS</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem offered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Technical Onboarding Manager (TOM)</strong>
+          <ul>
+            <li>Personal contact to assist with onboarding</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem">
+          <p>Provides initial guidance</p>
+        </td>
+        <td class="productTable-featureItem">
+          <p>Coordinates the process of getting your application up and running on AWS</p>
+        </td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Best practices and architecture</strong>
+          <ul>
+            <li>A combined set of AWS and Rackspace recommendations from certified AWS architects</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem">
+          <p>Guidance for standard use cases</p>
+        </td>
+        <td class="productTable-featureItem">
+          <p>Hands-on design, customized to your specific application</p>
+        </td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">EC2 operating system management</strong>
+          <ul>
+            <li>Support for Amazon Linux 2015.03+, CentOS 6/7, Ubuntu 12.04/14.04 LTS (Windows coming)</li>
+            <li>Configuration, optimization, patching, upgrades</li>
+            <li>Includes core apps like Apache, NGINX, etc.</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem notOffered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Monitoring Alarm Ticket Management</strong>
+          <ul>
+            <li>Setup of Watchman<sup>™</sup> monitors and response to Watchman<sup>™</sup> alarm tickets 24x7x365 by certified AWS engineers</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem notOffered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Monthly account review</strong>
+          <ul>
+            <li>Review AWS Trusted Advisor recommendations</li>
+            <li>Review Reserved Instance and other cost optimization opportunities</li>
+            <li>Technical environment review (alerts, performance)</li>
+          </ul>
+        </td>
+        <td class="productTable-featureItem notOffered"></td>
+        <td class="productTable-featureItem offered"></td>
+      </tr>
+      <tr class="productTable-row">
+        <td class="productTable-featureItem">
+          <strong class="productTable-strong">Response times</strong>
+        </td>
+        <td class="productTable-featureItem">
+          <p style="width: 110%; padding: 0 100px 0 0;">Urgent: &lt; 1 hour Standard: &lt; 12 hours</p>
+        </td>
+        <td class="productTable-featureItem">
+          <p>
+            Emergency: &lt; 15 min
+            Urgent: &lt; 1 hour
+            Standard: &lt; 4 hours
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/styleguide/js/zoolander.js
+++ b/styleguide/js/zoolander.js
@@ -111,8 +111,28 @@ jQuery(document).ready(function($) {
     });
 
     $('#footer-accordion').tabCollapse();
+    //initialize the responsive tables
+    $('.productTable').responsiveTable();
 });
 
+//responsive table jQuery plugin
+(function($){
+  'use strict';
+  $.fn.responsiveTable = function(){
+    var $table = $(this);
+    $table.each(function(){
+      var $el = $(this);
+      var $cellTitle = $el.find('.productTable-name');
+      //place table head titles into each cell as labels
+      $el.find('tbody tr td').each(function(){
+        var $index = $(this).index();
+        $(this).prepend('<strong class="productTable-mobileTitle">' + $cellTitle.eq($index).html() + ' </strong>');
+      });
+    });
+    //allow this plugin to be chainable via jQuery
+    return this;
+  };
+}(jQuery)); //to protect and scope the JQuery alias = $
 
 //swatches copy button
 (function() {


### PR DESCRIPTION
Moved over our old tables into a new maintainable pattern.

Desktop
<img width="809" alt="screen shot 2016-09-08 at 3 35 00 pm" src="https://cloud.githubusercontent.com/assets/4554644/18396584/148219d0-768a-11e6-842e-cb63a7ab17bd.png">

Mobile
<img width="511" alt="screen shot 2016-09-08 at 3 35 26 pm" src="https://cloud.githubusercontent.com/assets/4554644/18396590/1715f0f4-768a-11e6-8135-d10f00b5d67b.png">
