### PR TITLE
bug(nav): reduced padding for translations in nav

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -18,7 +18,7 @@
     color: $white;
     display: block;
     line-height: 2.1rem;
-    padding: 21px 15px;
+    padding: 21px 10px;
     text-decoration: none;
 
     &:hover,


### PR DESCRIPTION
Reduced padding on nav items so the nav doesn't break
![screen shot 2016-09-13 at 10 56 54 am](https://cloud.githubusercontent.com/assets/4554644/18481164/d187b210-79a0-11e6-8169-ad9ae446fa80.png)
