### PR TITLE
RSWEB-7235: update mobile banner min height

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -32,6 +32,10 @@ $banner-text-margin-medium: 10%;
   &.outlook {
     background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/backgrounds/o365-overview.jpg');
   }
+
+  .header-content {
+    margin-top: 25px;
+  }
 }
 
 .banner-headline {
@@ -149,6 +153,14 @@ $banner-text-margin-medium: 10%;
 }
 
 @media only screen and (max-width: $screen-xs-max) {
+  .banner {
+    min-height: 200px;
+
+    .header-content {
+      margin-top: 19px;
+    }
+  }
+
   .imacBanner {
     background-color: $black;
     background-image: none;


### PR DESCRIPTION
Updates min banner height for mobile to avoid long banner text being cut off or the banner background showing below the subnav.

- example page: https://www.rackspace.com/managed-aws

- Corresponding www PR with margin top being removed. (1276)