### PR TITLE
RSWEB-7348: bug(zoolanderNav): brought back nav slide toggle

### DIFF
--- a/styleguide/_layouts/default.jade
+++ b/styleguide/_layouts/default.jade
@@ -24,6 +24,7 @@ html(lang="en")
 
   .container-fluid
     .row.row-eq-height
+      button.navZoolander-slideBtn.navZoolander-leftArrow
       .navZoolander-container
         ul.navZoolander-list
           li.navZoolander-item
@@ -61,7 +62,7 @@ html(lang="en")
               li.navZoolander-dropdownItem
                 a(href="derek/assets/icon-font").navZoolander-dropdownLink Tabs
               li.navZoolander-dropdownItem
-                a(href="derek/assets/icon-font").navZoolander-dropdownLink Tables
+                a(href="derek/examples/tables").navZoolander-dropdownLink Tables
 
           li.navZoolander-item
             a(href="#").navZoolander-link.navZoolander-hasDropdown Derek Theme

--- a/styleguide/css/main.scss
+++ b/styleguide/css/main.scss
@@ -6,19 +6,57 @@ $bg-blue-gray: #2e3238;
 
 .mainContainer {
   padding-left: 260px;
+  transition: .5s;
   width: 100%;
+}
+
+.mainContainer-collapsed {
+  padding-left: 0;
 }
 
 .navZoolander-container {
   background-color: $bg-blue-gray;
   height: 100%;
   left: 0;
-  overflow-x: hidden;
+  overflow: auto;
   position: fixed;
   top: 0;
   transition: .5s;
   width: 250px;
-  z-index: 1;
+  z-index: 9999;
+}
+
+.navZoolander-slideBtn {
+  background-color: $bg-blue-gray;
+  border: 0;
+  color: $light-gray-white;
+  left: 250px;
+  padding: 8px 15px;
+  position: fixed;
+  transition: .5s;
+  z-index: 9999;
+
+  &::after {
+    content: '\f053';
+    font-family: 'FontAwesome';
+  }
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.navZoolander-container-collapsed {
+  margin-left: -250px;
+}
+
+.navZoolander-slideBtn-collapsed {
+  left: 0;
+
+  &::after {
+    content: '\f054';
+    font-family: 'FontAwesome';
+  }
 }
 
 .navZoolander-list,

--- a/styleguide/derek/examples/index.jade
+++ b/styleguide/derek/examples/index.jade
@@ -1,76 +1,72 @@
-extends ../../_layouts/page
+.container.standard-padding
+  .row
+    .col-md-12
+      h4.red Welcome to Global Ecomm's
+      h2.no-margin Derek Theme
 
-block page
-  .container.standard-padding
-    .row
-      .col-md-12
-        h4.red Welcome to Global Ecomm's
-        h2.no-margin Derek Theme
+  .row.standard-padding-full
+    .col-md-12
+      p Below is a list of examples to help you get started building your web pages.
 
-    .row.standard-padding-full
-      .col-md-12
-        p Below is a list of examples to help you get started building your web pages.
+  .row
+    .col-md-12
+      h2.red Templates
+    .col-md-4
+      h5 Landing Pages
+      a(href="derek/examples/landing-page/")
+        img.img-thumbnail(src="imgs/derek/examples/landing-page.png")
+      p Landing Pages
+    .col-md-4
+      h5 Section Overview
+      a(href="derek/examples/section-overview")
+        img.img-thumbnail(src="imgs/derek/examples/section-overview.png")
+      p Section Overview
+    .col-md-4
+      h5 Product Overview
+      a(href="derek/examples/#")
+        img.img-thumbnail(src="http://placehold.it/240x300")
+      p Product Overview (needs development)
 
-    .row
-      .col-md-12
-        h2.red Templates
-      .col-md-4
-        h5 Landing Pages
-        a(href="derek/examples/landing-page/")
-          img.img-thumbnail(src="imgs/derek/examples/landing-page.png")
-        p Landing Pages
-      .col-md-4
-        h5 Section Overview
-        a(href="derek/examples/section-overview")
-          img.img-thumbnail(src="imgs/derek/examples/section-overview.png")
-        p Section Overview
-      .col-md-4
-        h5 Product Overview
-        a(href="derek/examples/#")
-          img.img-thumbnail(src="http://placehold.it/240x300")
-        p Product Overview (needs development)
+  hr
 
-    hr
+  .row.half-padding
+    .col-md-12
+      h2.red Solutions
+    .col-md-4
+      h5 Pattern Library
+      a(href="derek/examples/solutions")
+        img.img-thumbnail(src="imgs/derek/examples/solutions.png")
+    .col-md-4
+      h5 Subpanels Library
+      a(href="derek/examples/subpanels")
+        img.img-thumbnail(src="imgs/derek/examples/subpanels.png")
 
-    .row.half-padding
-      .col-md-12
-        h2.red Solutions
-      .col-md-4
-        h5 Pattern Library
-        a(href="derek/examples/solutions")
-          img.img-thumbnail(src="imgs/derek/examples/solutions.png")
-      .col-md-4
-        h5 Subpanels Library
-        a(href="derek/examples/subpanels")
-          img.img-thumbnail(src="imgs/derek/examples/subpanels.png")
+  hr
 
-    hr
-
-    .row.half-padding
-      .col-md-12
-        h2.red  Inspiration and Examples
-    .row
-      .col-md-4
-        h5 IMAC Banners
-        a(href="derek/examples/imac")
-          img.img-thumbnail(src="http://placehold.it/240x300")
-      .col-md-4
-        h5 O365
-        a(href="derek/examples/office365")
-          img.img-thumbnail(src="imgs/derek/examples/0365.png")
-      .col-md-4
-        h5 Homepage
-        a(href="derek/examples/homepage")
-          img.img-thumbnail(src="imgs/derek/examples/homepage.png")
-    .row
-      .col-md-4
-        h5 Event Overview
-        a(href="derek/examples/events")
-          img.img-thumbnail(src="imgs/derek/examples/event-overview.png")
-      .col-md-4
-        h5 Event Interior
-        a(href="derek/examples/events-interior")
-          img.img-thumbnail(src="imgs/derek/examples/event-interior.png")
-      .col-md-4
-        h5 Ticker? More Examples.
-
+  .row.half-padding
+    .col-md-12
+      h2.red  Inspiration and Examples
+  .row
+    .col-md-4
+      h5 IMAC Banners
+      a(href="derek/examples/imac")
+        img.img-thumbnail(src="http://placehold.it/240x300")
+    .col-md-4
+      h5 O365
+      a(href="derek/examples/office365")
+        img.img-thumbnail(src="imgs/derek/examples/0365.png")
+    .col-md-4
+      h5 Homepage
+      a(href="derek/examples/homepage")
+        img.img-thumbnail(src="imgs/derek/examples/homepage.png")
+  .row
+    .col-md-4
+      h5 Event Overview
+      a(href="derek/examples/events")
+        img.img-thumbnail(src="imgs/derek/examples/event-overview.png")
+    .col-md-4
+      h5 Event Interior
+      a(href="derek/examples/events-interior")
+        img.img-thumbnail(src="imgs/derek/examples/event-interior.png")
+    .col-md-4
+      h5 Ticker? More Examples.

--- a/styleguide/derek/examples/landing-page/_layout.jade
+++ b/styleguide/derek/examples/landing-page/_layout.jade
@@ -1,4 +1,0 @@
-extends ../../../_layouts/page
-
-block content
-  != yield

--- a/styleguide/derek/examples/landing-page/index.jade
+++ b/styleguide/derek/examples/landing-page/index.jade
@@ -1,31 +1,28 @@
-extends ../../../_layouts/page
+.container.standard-padding
+  .row
+    .col-md-12
+      h4.red Landing Page
+      h2.no-margin Examples and Best Practices
 
-block page
-  .container.standard-padding
-    .row
-      .col-md-12
-        h4.red Landing Page
-        h2.no-margin Examples and Best Practices
+  .row.standard-padding-full
+    .col-md-12
+      p INSERT BEST PRACTICES.
 
-    .row.standard-padding-full
-      .col-md-12
-        p INSERT BEST PRACTICES.
-
-    .row
-      .col-md-12
-        h2.red Templates
-      .col-md-4
-        h5 CTA Landing Page
-        a(href="derek/examples/landing-page/cta-LP")
-          img.img-thumbnail(src="imgs/derek/examples/landing-page.png")
-        p Landing Page
-      .col-md-4
-        h5 Video Landing Page
-        a(href="derek/examples/landing-page/video-LP")
-          img.img-thumbnail(src="http://placehold.it/240x300")
-        p Video Landing Page
-      .col-md-4
-        h5 Form Landing Page
-        a(href="derek/examples/landing-page/form-LP")
-          img.img-thumbnail(src="http://placehold.it/240x300")
-        p Form Landing Page
+  .row
+    .col-md-12
+      h2.red Templates
+    .col-md-4
+      h5 CTA Landing Page
+      a(href="derek/examples/landing-page/cta-LP")
+        img.img-thumbnail(src="imgs/derek/examples/landing-page.png")
+      p Landing Page
+    .col-md-4
+      h5 Video Landing Page
+      a(href="derek/examples/landing-page/video-LP")
+        img.img-thumbnail(src="http://placehold.it/240x300")
+      p Video Landing Page
+    .col-md-4
+      h5 Form Landing Page
+      a(href="derek/examples/landing-page/form-LP")
+        img.img-thumbnail(src="http://placehold.it/240x300")
+      p Form Landing Page

--- a/styleguide/js/zoolander.js
+++ b/styleguide/js/zoolander.js
@@ -148,3 +148,19 @@ $('.navZoolander-hasDropdown').unbind().click(function(e){
   $el.next('.navZoolander-dropdown').slideToggle(200);
   $el.toggleClass('hasDropDown-active');
 });
+
+//Slide toggle the zoolander nav
+var zoolanderSlideBtn = $('.navZoolander-slideBtn');
+zoolanderSlideBtn.unbind().click(function(e){
+  e.preventDefault();
+  var $me = $(this);
+  $me.toggleClass('navZoolander-slideBtn-collapsed');
+  $me.next('.navZoolander-container').toggleClass('navZoolander-container-collapsed');
+  $('.mainContainer').toggleClass('mainContainer-collapsed');
+});
+
+//Zoolander only solution for auto collapsing menu on example pages
+var url = window.location.pathname;
+if(url.match(/\/derek\/examples\//gi) && url != '/derek/examples/' && url != '/derek/examples/landing-page/'){
+    zoolanderSlideBtn.trigger('click');
+}


### PR DESCRIPTION
@amberRrucker @WidgetsBurritos Can I get code/design review:

- Brought back the slide toggle ability for better previewing landing pages. 
- Made the navbar scrollable incase all are collapsed/or if we add more links.
- Fixed a bug that double injects content on some pages (ex: /derek/examples/landing-page/) thus  causing nav click events to run twice. 
- Added proper tables link

<img width="502" alt="screen shot 2016-09-22 at 3 08 35 pm" src="https://cloud.githubusercontent.com/assets/4554644/18764336/899cb01c-80d6-11e6-9ca2-fee06d1cf228.png">

<img width="488" alt="screen shot 2016-09-22 at 3 08 53 pm" src="https://cloud.githubusercontent.com/assets/4554644/18764340/8dea2366-80d6-11e6-8117-9919f40350f3.png">
