### PR TITLE
RSWEB-7381: Adds additional padding to top to account for fixed nav

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -52,7 +52,7 @@ $banner-text-margin-medium: 10%;
   color: $white;
   margin-top: 50px;
   overflow: hidden;
-  padding: 70px 0 50px 0;
+  padding: 95px 0 50px 0;
 }
 
 .imacBanner-container {


### PR DESCRIPTION
This PR fixes a padding issue on imac banners caused by removal of a margin last week. 