### PR TITLE
RSWEB-7415: adjusting background position to remediate cutting off…

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -47,7 +47,8 @@ $banner-text-margin-medium: 10%;
 
 
 .imacBanner {
-  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/backgrounds/o365-overview.jpg');
+  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/IMACbanners/collaboration-2.jpg');
+  background-position: right center;
   background-size: cover;
   color: $white;
   margin-top: 50px;


### PR DESCRIPTION
RSWEB-7415

Needed to adjust background position for imac banners to keep the subject of our images from being cut off on the right.