### PR TITLE
RSWEB-7397: imac-banner-button-padding-only

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -105,6 +105,7 @@ $banner-text-margin-medium: 10%;
   color: $white;
   font-weight: 600;
   margin-left: 20px;
+  padding: 8px 20px;
 
   &:hover {
     background-color: darken($brand-primary, 5%);


### PR DESCRIPTION
RSWEB-7397

Reducing button padding for imac banner button ONLY to 8px top/bottom
Visible here:
http://localhost:9000/derek/examples/imac