### PR TITLE
rsweb-7350-headline-font-change

### DIFF
--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -1,4 +1,4 @@
-$heading: 'Open Sans', Helvetica, Arial, sans-serif;
+$heading: 'Khand', Helvetica, Arial, sans-serif;
 $subhead: 'Montserrat', Helvetica, Arial, sans-serif;
 $copy: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $code: Tahoma, Arial, Geneva, Helvetica;
@@ -6,14 +6,14 @@ $code: Tahoma, Arial, Geneva, Helvetica;
 @mixin heading($color: $gray-darkest) {
   color: $color;
   font-family: $heading;
-  font-weight: 200;
+  font-weight: 600;
   text-transform: uppercase;
 }
 
 @mixin subhead($color: $gray-darkest) {
   color: $color;
   font-family: $subhead;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.45em;
   text-align: left;
   text-transform: uppercase;


### PR DESCRIPTION
RSWEB-7350
style(zoolander):headline font switch

Switching our headline (h1-h3) font to Khand and adjusting for font weight.
Will has taken a look and approved. Should be previewed on this page: 
http://localhost:9000/derek/examples/solutions-usage to see how it interacts with out patterns

here:
http://localhost:9000/derek/examples/homepage to see how it interacts on the homepage

and then here: 
http://localhost:9000/derek/assets/typography to see it with other typographic examples

Should have code review, design review, review from @ejchiefs then put on staging for the ECMs to review.