### PR TITLE
rsweb-7420-table-fontsize

### DIFF
--- a/styleguide/_themes/global/scss/tables.scss
+++ b/styleguide/_themes/global/scss/tables.scss
@@ -9,6 +9,8 @@ $table-padding: 20px 5px;
 .productTable-featureItem,
 .productTable-name {
   border: 1px solid $gray-lighter;
+  font-size: 1.35rem;
+  line-height: 2rem;
 }
 
 .productTable-name {


### PR DESCRIPTION
bug(zoolander):table font size overridden by www

Can be viewed here (but should be the same):
http://localhost:9000/derek/examples/tables

Fixes issues here: 
https://admin.rackspace.com/node/5725