### PR TITLE
RSWEB-7435: imac-banner-padding

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -51,9 +51,9 @@ $banner-text-margin-medium: 10%;
   background-position: right center;
   background-size: cover;
   color: $white;
-  margin-top: 50px;
+  margin-top: 98px;
   overflow: hidden;
-  padding: 95px 0 50px 0;
+  padding: 50px 0;
 }
 
 .imacBanner-container {
@@ -79,8 +79,6 @@ $banner-text-margin-medium: 10%;
 
 .imacBanner-headline {
   @include heading($white);
-  // will be removing this line when imac comes out because we're actually going to be switching the heading mixin to use Khand anyways
-  font-family: 'Khand';
   font-size: 4rem;
   font-weight: 700;
   line-height: .9em;
@@ -148,9 +146,17 @@ $banner-text-margin-medium: 10%;
   }
 }
 
+.landingpage-wrapper {
+
+  .imacBanner {
+    margin-top: 50px;
+  }
+}
+
 @media only screen and (max-width: $screen-sm-max) {
   .imacBanner {
-    padding: 63px 15px 50px;
+    margin-top: 63px;
+    padding: 50px 15px;
   }
 }
 
@@ -167,7 +173,7 @@ $banner-text-margin-medium: 10%;
     background-blend-mode: color;
     background-color: $black;
     background-image: none;
-    padding: 63px 15px 50px;
+    padding: 50px 15px;
   }
 
   .imacBanner-button {

--- a/styleguide/derek/examples/landing-page/cta-LP.ejs
+++ b/styleguide/derek/examples/landing-page/cta-LP.ejs
@@ -1,11 +1,15 @@
-<%- partial("../../_partials/_ceilingLp") %>
+<div class="landingpage-wrapper">
 
-<%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
+  <%- partial("../../_partials/_ceilingLp") %>
 
-<%- partial("../../_partials/solutions/value-prop.ejs") %>
+  <%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
 
-<%- partial("../../_partials/solutions/testimonials.ejs") %>
+  <%- partial("../../_partials/solutions/value-prop.ejs") %>
 
-<%- partial("../../_partials/solutions/cta.ejs") %>
+  <%- partial("../../_partials/solutions/testimonials.ejs") %>
 
-<%- partial("../../_partials/solutions/footer.ejs") %>
+  <%- partial("../../_partials/solutions/cta.ejs") %>
+
+  <%- partial("../../_partials/solutions/footer.ejs") %>
+
+</div>

--- a/styleguide/derek/examples/landing-page/form-LP.ejs
+++ b/styleguide/derek/examples/landing-page/form-LP.ejs
@@ -1,13 +1,17 @@
-<%- partial("../../_partials/_ceilingLp") %>
+<div class="landingpage-wrapper">
 
-<%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
+  <%- partial("../../_partials/_ceilingLp") %>
 
-<%- partial("../../_partials/solutions/LP-form.ejs") %>
+  <%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
 
-<%- partial("../../_partials/solutions/value-prop.ejs") %>
+  <%- partial("../../_partials/solutions/LP-form.ejs") %>
 
-<%- partial("../../_partials/solutions/testimonials.ejs") %>
+  <%- partial("../../_partials/solutions/value-prop.ejs") %>
 
-<%- partial("../../_partials/solutions/cta.ejs") %>
+  <%- partial("../../_partials/solutions/testimonials.ejs") %>
 
-<%- partial("../../_partials/solutions/footer.ejs") %>
+  <%- partial("../../_partials/solutions/cta.ejs") %>
+
+  <%- partial("../../_partials/solutions/footer.ejs") %>
+
+</div>

--- a/styleguide/derek/examples/landing-page/video-LP.ejs
+++ b/styleguide/derek/examples/landing-page/video-LP.ejs
@@ -1,13 +1,17 @@
-<%- partial("../../_partials/_ceilingLp") %>
+<div class="landingpage-wrapper">
 
-<%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
+  <%- partial("../../_partials/_ceilingLp") %>
 
-<%- partial("../../_partials/solutions/video.ejs") %>
+  <%- partial("../../_partials/solutions/header-mediumIMAC.ejs") %>
 
-<%- partial("../../_partials/solutions/value-prop.ejs") %>
+  <%- partial("../../_partials/solutions/video.ejs") %>
 
-<%- partial("../../_partials/solutions/testimonials.ejs") %>
+  <%- partial("../../_partials/solutions/value-prop.ejs") %>
 
-<%- partial("../../_partials/solutions/cta.ejs") %>
+  <%- partial("../../_partials/solutions/testimonials.ejs") %>
 
-<%- partial("../../_partials/solutions/footer.ejs") %>
+  <%- partial("../../_partials/solutions/cta.ejs") %>
+
+  <%- partial("../../_partials/solutions/footer.ejs") %>
+
+</div>


### PR DESCRIPTION
RSWEB-7435

bug(zoolander):imac banner padding issues

Adjusting imac banner padding and top margins to not be covered by main nav. Had to wrap landing page in a wrapper. DO NOT MERGE UNTIL LANDING PAGES ARE WRAPPED IN landingpage-wrapper

Fix can be seen here: 
http://localhost:9000/derek/examples/homepage

as well as here:
http://localhost:9000/derek/examples/landing-page/cta-LP