### PR TITLE
rsweb-7441-subhead-switch

### DIFF
--- a/styleguide/_layouts/default.jade
+++ b/styleguide/_layouts/default.jade
@@ -16,7 +16,7 @@ html(lang="en")
 
     link(href="#{ css }", rel="stylesheet")
     link(href="css/main.css", rel="stylesheet")
-    link(href="https://fonts.googleapis.com/css?family=Open+Sans:700,300,200,600,800,400|Khand:700,600,500|Montserrat:400,700", rel="stylesheet")
+    link(href="https://fonts.googleapis.com/css?family=Open+Sans:700,300,200,600,800,400", rel="stylesheet")
     link(href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" rel="stylesheet")
     script(src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous")
     script(src="https://577351e10bc4a0198d93-f60a0bb748a3c84145bb10da7563bafb.ssl.cf1.rackcdn.com/zoolander/modernizr.min.js")

--- a/styleguide/_themes/global/scss/bootstrap_variables.scss
+++ b/styleguide/_themes/global/scss/bootstrap_variables.scss
@@ -54,7 +54,7 @@ $link-hover-decoration: underline !default;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif:  "Montserrat", Arial, sans-serif !default;
+$font-family-sans-serif:  "Khand", Arial, sans-serif !default;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace !default;

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -1,5 +1,5 @@
 $heading: 'Khand', Helvetica, Arial, sans-serif;
-$subhead: 'Montserrat', Helvetica, Arial, sans-serif;
+$subhead: 'Khand', Helvetica, Arial, sans-serif;
 $copy: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $code: Tahoma, Arial, Geneva, Helvetica;
 
@@ -13,10 +13,10 @@ $code: Tahoma, Arial, Geneva, Helvetica;
 @mixin subhead($color: $gray-darkest) {
   color: $color;
   font-family: $subhead;
-  font-weight: 400;
+  font-weight: 500;
+  letter-spacing: .05em;
   line-height: 1.45em;
   text-align: left;
-  text-transform: uppercase;
 }
 
 @mixin copy($color: $gray-darkest) {
@@ -59,6 +59,18 @@ h4,
 h5,
 h6 {
   @include subhead;
+}
+
+h4 {
+  font-size: 2rem;
+}
+
+h5 {
+  font-size: 1.75rem;
+}
+
+h6 {
+  font-size: 1.5rem;
 }
 
 ul {

--- a/styleguide/derek/assets/typography.jade
+++ b/styleguide/derek/assets/typography.jade
@@ -19,9 +19,9 @@
   .row.half-padding-full
     .col-md-12
       h4.red Subhead Usage
-      p H4-h6 can be used in all caps only.
+      p H4-h6 can be used in title case only.
       br
-      | They use Montserrat <code>$subhead</code>, uppercase <code>.uppercase;</code>, and a font-weight of 600 <code>.semi-bold</code>.
+      | They use Khand <code>$subhead</code> and a font-weight of 500.
       include ../_partials/typography/subhead.ejs
 
   hr


### PR DESCRIPTION
RSWEB-7441
style(zoolander):subhead font switch

Can be viewed on homepage and solutions examples page to check for any weirdness.