### PR TITLE
RSWEB-7338: Add logo to banner, swap company bio/outcome

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/stories.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/stories.scss
@@ -1,5 +1,19 @@
 .imacBanner-stories {
-  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/IMACbanners/racker-working-1.jpg');
+  background-color: $black;
+  background-image: none;
+  min-height: inherit;
+}
+
+.imacBanner-storiesTextRow {
+  position: relative;
+}
+
+.imacBanner-storyLogoImage {
+  height: 95px;
+  position: absolute;
+  right: 0;
+  top: -15px;
+  width: auto;
 }
 
 .story-colLeft {
@@ -99,4 +113,8 @@
   &:hover {
     background-color: $gray-dark;
   }
+}
+
+@media (max-width: $screen-xs-max) {
+  @include responsive-invisibility('.imacBanner-storyLogo');
 }

--- a/styleguide/derek/examples/stories-interior.ejs
+++ b/styleguide/derek/examples/stories-interior.ejs
@@ -4,12 +4,15 @@
 <!--Header Short-->
 <div class="imacBanner imacBanner-stories">
   <div class="imacBanner-container">
-    <div class="imacBanner-textRow">
+    <div class="imacBanner-textRow imacBanner-storiesTextRow">
       <div class="imacBanner-textContainer imacBanner-headlineSmall">
         <h2 class="imacBanner-headline">Customer Stories</h2>
         <span class="imacBanner-line left-top"></span>
         <span class="imacBanner-line left-bottom"></span>
         <span class="imacBanner-line right-bottom"></span>
+      </div>
+      <div class="imacBanner-storyLogo">
+        <img class="imacBanner-storyLogoImage" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="Under Armour">
       </div>
     </div>
   </div>
@@ -24,7 +27,7 @@
   </div>
   <div class="row">
     <div class="story-colLeft">
-      <p>The company is the developer, marketer, and supplier of a wide range of sportswear and casual apparel mainly focusing on hi-tech sportswear for professional athletes. Under Armour began offering footwear in 2006, and now operates as a global company with offices in Denver, Amsterdam, Denver, Hong Kong, Toronto and Guangzhou, China.</p>
+      <p>A high performance site infrastructure, plus the Fanatical Support service and uptime they required.</p>
       <p><a href="javascript: void(0);" class="story-caseStudyButton">Read the Case Study</a></p>
     </div>
     <div class="story-colRight">
@@ -53,8 +56,8 @@
       </p>
     </div>
     <div class="story-colRight">
-      <h2 class="story-subtitle">Outcome</h2>
-      <p>A high performance site infrastructure, plus the Fanatical Support service and uptime they required.</p>
+      <h2 class="story-subtitle">About the Customer</h2>
+      <p>The company is the developer, marketer, and supplier of a wide range of sportswear and casual apparel mainly focusing on hi-tech sportswear for professional athletes. Under Armour began offering footwear in 2006, and now operates as a global company with offices in Denver, Amsterdam, Denver, Hong Kong, Toronto and Guangzhou, China.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR removes the image and adds a logo to the imac banner on stories and swaps the company bio/outcome statements. 

![image](https://cloud.githubusercontent.com/assets/5263371/19046102/92a8ab6e-8961-11e6-9c0d-0c664a016dcd.png)
