### PR TITLE
RSWEB-7179: style(nav): increase font size for links

### DIFF
--- a/styleguide/_themes/derek/scss/components/subnav.scss
+++ b/styleguide/_themes/derek/scss/components/subnav.scss
@@ -74,7 +74,8 @@
 
 .subnav-link {
   color: $white;
-  font-weight: 300;
+  font-size: .95em;
+  font-weight: 400;
   padding-bottom: 16px;
   padding-top: 12px;
   text-decoration: none;

--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -43,7 +43,7 @@
     .navbar-dropDownLink,
     .navbar-tertiary-dropDownLink {
       color: $white;
-      font-size: .8em;
+      font-size: .95em;
       line-height: 1.5em;
       padding: 6px 15px;
       text-decoration: none;
@@ -58,7 +58,7 @@
 
     .navbar-dropDownLabel {
       color: $gray-light;
-      font-size: .9em;
+      font-size: .95em;
       line-height: 1.5em;
       margin: 0;
       padding: 6px 15px;
@@ -307,6 +307,7 @@
       .navbar-dropDownLink,
       .navbar-dropDownLabel,
       .navbar-tertiary-dropDownLink {
+        font-size: .8em;
         padding: 7px 15px 7px 25px;
       }
 


### PR DESCRIPTION
Increased the font size on drop down links in global nav and increased font weight/size on sub navs to match global nav
<img width="1061" alt="screen shot 2016-10-04 at 1 10 14 pm" src="https://cloud.githubusercontent.com/assets/4554644/19086622/7dfd5c0e-8a34-11e6-86d8-c6fd41b1bd73.png">
