### PR TITLE
RSWEB-7287: QE Bugfixes

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
@@ -53,4 +53,5 @@
 
 .resource {
   @include flex-box;
+  width: 100%;
 }

--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -69,3 +69,14 @@
   background-color: $gray-light;
   background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/elements/bg-crumpled-paper.png');
 }
+
+// Custom offset classes for panel-flex boxes.
+@media (min-width: $screen-sm-min) {
+  .panel-flexPush-2 {
+    margin-left: 16.7%;
+  }
+
+  .panel-flexPull-2 {
+    margin-right: 16.7%;
+  }
+}

--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -1,8 +1,15 @@
+.panel-pane {
+  width: 100%;
+}
+
 .panel-flex {
   @include flex-box;
-  @include flex-vertical;
   justify-content: center;
   width: 100%;
+}
+
+.panel-flexVertical {
+  @include flex-vertical;
 }
 
 .subpanel {

--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -2,6 +2,7 @@
   @include flex-box;
   @include flex-vertical;
   justify-content: center;
+  width: 100%;
 }
 
 .subpanel {


### PR DESCRIPTION
First commit - Fixes flex widths not spanning 100%. 
Second commit - Adds maintainable "push" classes for panel-flex, that use `margin-left` instead of `left`.