### PR TITLE
RSWEB-7523+RSWEB-7524: Removing 960 max-width

### DIFF
--- a/styleguide/_themes/derek/scss/modifiers.scss
+++ b/styleguide/_themes/derek/scss/modifiers.scss
@@ -1,10 +1,5 @@
 $body-bg:  #fff !default;
 
-// Temporary to restrict to 960px
-.container {
-  max-width: 960px;
-}
-
 // Component
 .river {
   padding: 12px 0;

--- a/styleguide/_themes/global/scss/bootstrap_variables.scss
+++ b/styleguide/_themes/global/scss/bootstrap_variables.scss
@@ -372,7 +372,7 @@ $container-desktop:            (940px + $grid-gutter-width) !default;
 $container-md:                 $container-desktop !default;
 
 // Large screen / wide desktop
-$container-large-desktop:      (1140px + $grid-gutter-width) !default;
+$container-large-desktop:      (1230px + $grid-gutter-width) !default;
 //** For `$screen-lg-min` and up.
 $container-lg:                 $container-large-desktop !default;
 

--- a/styleguide/_themes/global/scss/bootstrap_variables.scss
+++ b/styleguide/_themes/global/scss/bootstrap_variables.scss
@@ -349,7 +349,7 @@ $screen-md-max:              ($screen-lg-min - 1) !default;
 //** Number of columns in the grid.
 $grid-columns:              12 !default;
 //** Padding between columns. Gets divided in half for the left and right.
-$grid-gutter-width:         30px !default;
+$grid-gutter-width:         50px !default;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
 $grid-float-breakpoint:     $screen-sm-min !default;

--- a/styleguide/_themes/global/scss/global.scss
+++ b/styleguide/_themes/global/scss/global.scss
@@ -47,9 +47,3 @@
 @import 'buttons';
 @import 'banners';
 @import 'bootstrap_overrides';
-
-@media screen and (min-width: $screen-md-min) {
-  .container {
-    width: 960px;
-  }
-}

--- a/styleguide/_themes/global/scss/grid.scss
+++ b/styleguide/_themes/global/scss/grid.scss
@@ -2,7 +2,7 @@
   @include container-fixed;
 }
 
-@mixin make-container($max-width: 960px) {
+@mixin make-container($max-width: 1280px) {
   @include container-fixed;
   max-width: $max-width;
 


### PR DESCRIPTION
Removed or changed the max width of 960 where applicable. Can we seen across all examples pages. Need to make sure it hasn't broken the actual containers. There will be styling issues that will get addressed with other PRs.
