### PR TITLE
RSWEB-7468: panel flex mixin for stacked content

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -1,5 +1,6 @@
 .panel-flex {
   @include flex-box;
+  @include flex-vertical;
   justify-content: center;
 }
 

--- a/styleguide/_themes/global/scss/vendor_prefixes.scss
+++ b/styleguide/_themes/global/scss/vendor_prefixes.scss
@@ -54,6 +54,14 @@
   display: flex;
 }
 
+@mixin flex-vertical {
+  -moz-box-orient: vertical;
+  -ms-flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
 @mixin sepia-filter {
   -webkit-filter: sepia(.9);
   filter: sepia(90%);


### PR DESCRIPTION
Sets `.panel-flex` to stack vertically.

This closes alternate PR https://github.com/rackerlabs/zoolander/pull/279.