### PR TITLE
rsweb-7349-cta-refactor-and-width-change

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -264,6 +264,7 @@
 
 .navbar-searchButton {
   float: right;
+  font-size: 1.2rem;
   margin: 0;
   opacity: .7;
   padding: 6.5px;

--- a/styleguide/_themes/global/scss/buttons.scss
+++ b/styleguide/_themes/global/scss/buttons.scss
@@ -4,13 +4,14 @@
   box-shadow: none;
   cursor: pointer;
   display: inline-block;
-  font-size: .85em;
+  font-family: $heading;
+  font-size: 1.5rem;
   font-weight: $font-weight-black;
-  padding: 15px 20px;
+  letter-spacing: .1rem;
+  margin: 0 auto;
+  padding: 11px 50px;
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
-  width: 100%;
 
   &:hover {
     text-decoration: none;
@@ -51,22 +52,6 @@
   }
 }
 
-.banner {
-  .button {
-    background: transparent;
-    color: $white;
-
-    &.learning {
-      background-color: transparent;
-      color: $white;
-
-      &:hover {
-        background-color: $brand-secondary;
-      }
-    }
-  }
-}
-
 .button {
   @include button;
 
@@ -104,6 +89,49 @@
       text-decoration: none;
     }
   }
+}
+
+.cta-container {
+  padding: $standard-padding;
+}
+
+.cta-iconRow,
+.cta-titleRow,
+.cta-subheadRow,
+.cta-buttonRow,
+.cta-subtextRow {
+  @include make-row;
+}
+
+.cta-icon {
+  display: block;
+  text-align: center;
+}
+
+.cta-title {
+  margin-bottom: 3px;
+  text-align: center;
+}
+
+.cta-subhead {
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+.cta-buttonContainer {
+  margin: 5px 0;
+}
+
+.cta-button {
+  @include button;
+  @include button-lead;
+  display: table;
+}
+
+.cta-subtext {
+  font-size: 1.25rem;
+  font-weight: 400;
+  text-align: center;
 }
 
 .subnav {

--- a/styleguide/derek/_partials/solutions/cta-bottom.ejs
+++ b/styleguide/derek/_partials/solutions/cta-bottom.ejs
@@ -1,23 +1,11 @@
 <!-- CTA -->
-<div class="container standard-padding">
-  <div class="row">
-    <div class="col-xs-1 center-block">
-      <i class="rsweb gen-assistance"></i>
-    </div>
+<div class="cta-container">
+  <div class="cta-titleRow">
+    <h2 class="cta-title">Talk to a Rackspace Specialist</h2>
   </div>
-  <div class="row">
-    <div class="col-md-8 center-block">
-      <h2 class="center">Talk to a Rackspace Specialist</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-4 col-sm-6 center-block">
-      <a class="button lead">Chat Now</a>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-8 center-block">
-      <h4 class="center">Call 1-855-715-7307</h4>
+  <div class="cta-buttonRow">
+    <div class="cta-buttonContainer">
+      <a class="cta-button">Talk to a Specialist</a>
     </div>
   </div>
 </div>

--- a/styleguide/derek/_partials/solutions/cta.ejs
+++ b/styleguide/derek/_partials/solutions/cta.ejs
@@ -1,13 +1,21 @@
 <!-- CTA -->
-<div class="container half-padding">
-  <div class="row">
-    <div class="col-md-8 center-block">
-      <h2 class="center">ANY QUESTIONS? </h2>
+<div class="cta-container">
+  <div class="cta-iconRow">
+    <i class="cta-icon rsweb gen-assistance"></i>
+  </div>
+  <div class="cta-titleRow">
+    <h2 class="cta-title">Talk to a Rackspace Specialist</h2>
+  </div>
+  <div class="cta-subheadRow">
+    <p class="cta-subhead">Combine the benefits of exchange with the savings of Rackspace email</p>
+  </div>
+  <div class="cta-buttonRow">
+    <div class="cta-buttonContainer">
+      <a class="cta-button">Talk to a Specialist</a>
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-4 col-sm-6 center-block">
-      <a class="button lead">Get a Free Consultation</a>
-    </div>
+  <div class="cta-subtextRow">
+    <h6 class="cta-subtext">Call 1-855-715-7307 to start saving</h6>
   </div>
 </div>
+

--- a/styleguide/derek/assets/buttons.jade
+++ b/styleguide/derek/assets/buttons.jade
@@ -2,15 +2,28 @@
   .col-md-4.col-sm-6
     h5 Lead Generating
     a.button.lead Get a Free Consultation
-    p For use for a cta. To chat, sign-up or complete a form. Anything directly lead generating.
+    p.center For use for a cta. To chat, sign-up or complete a form. Anything directly lead generating.
 
   .col-md-4.col-sm-6
     h5 Learning
     a.button.learning Learn More
-    p For use for an internally redirecting link. Learn More, Read More, Compare Prices ect. Something that doesn’t directly begin conversation or lead generation.
+    p.center For use for an internally redirecting link. Learn More, Read More, Compare Prices ect. Something that doesn’t directly begin conversation or lead generation.
 
   .col-md-4.col-sm-6
     h5 Leaving the Funnel
     a.button.leaving Customer Stories
-    p For use for an external link to customer stories/support or other things owned by external rackspace domains. Always open in new tab or window.
+    p.center For use for an external link to customer stories/support or other things owned by external rackspace domains. Always open in new tab or window.
 
+.row.half-padding-top
+  .cta-container
+    .cta-iconRow
+      i.cta-icon.rsweb.gen-assistance
+    .cta-titleRow
+      h2.cta-title Talk to a Rackspace Specialist
+    .cta-subheadRow
+      p.cta-subhead Combine the benefits of exchange with the savings of Rackspace email
+    .cta-buttonRow
+      .cta-buttonContainer
+        a.cta-button Talk to a Specialist
+    .cta-subtextRow
+      h6.cta-subtext Call 1-855-715-7307 to start saving


### PR DESCRIPTION
RSWEB-7349

style(cta):removing 100% cta width
Removing 100% width as well as refactoring and adjusting design for cta pattern

Changes can be seen/tested on 
http://localhost:9000/derek/assets/buttons
http://localhost:9000/derek/examples/solutions and
http://localhost:9000/derek/examples/homepage

Looking to make sure this won't break buttons in production either. Should try and put on staging for full visual testing.
