### PR TITLE
RSWEB-7341: Allow for text in addition to logos

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/stories.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/stories.scss
@@ -1,3 +1,8 @@
+.story-container {
+  @include make-container;
+  padding: $standard-padding;
+}
+
 .imacBanner-stories {
   background-color: $black;
   background-image: none;
@@ -100,21 +105,38 @@
   padding: 5px;
 }
 
-.storyOverview-logo {
-  background-color: $gray-base;
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: 75px;
-  display: block;
-  min-height: 125px;
-  padding: 15px 5px;
-  text-indent: -10000px;
+.storyOverview-itemLink {
+  @include flex-box;
+  @include flex-center;
+  background: $gray-base;
+  height: 125px;
+  text-align: center;
+  text-decoration: none;
 
   &:hover {
     background-color: $gray-dark;
+    text-decoration: none;
   }
+}
+
+.storyOverview-logo {
+  max-width: 50%;
+}
+
+.storyOverview-logoText {
+  color: $white;
+  font-size: 1.8rem;
+  max-width: 80%;
 }
 
 @media (max-width: $screen-xs-max) {
   @include responsive-invisibility('.imacBanner-storyLogo');
+
+  .story-container {
+    padding: 0 $grid-gutter-width / 2;
+  }
+
+  .storyOverview-logo {
+    max-width: 120px;
+  }
 }

--- a/styleguide/_themes/derek/scss/snowflakes/stories.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/stories.scss
@@ -13,12 +13,16 @@
   position: relative;
 }
 
-.imacBanner-storyLogoImage {
-  height: 95px;
+.imacBanner-storyLogo {
+  @include flex-box;
+  @include flex-center;
+  height: 65px;
   position: absolute;
   right: 0;
-  top: -15px;
-  width: auto;
+}
+
+.imacBanner-storyLogoImage {
+  max-height: 95px;
 }
 
 .story-colLeft {

--- a/styleguide/_themes/global/scss/vendor_prefixes.scss
+++ b/styleguide/_themes/global/scss/vendor_prefixes.scss
@@ -62,6 +62,15 @@
   flex-direction: column;
 }
 
+@mixin flex-center {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 @mixin sepia-filter {
   -webkit-filter: sepia(.9);
   filter: sepia(90%);

--- a/styleguide/derek/examples/stories-interior.ejs
+++ b/styleguide/derek/examples/stories-interior.ejs
@@ -1,69 +1,71 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
 
-<!--Header Short-->
-<div class="imacBanner imacBanner-stories">
-  <div class="imacBanner-container">
-    <div class="imacBanner-textRow imacBanner-storiesTextRow">
-      <div class="imacBanner-textContainer imacBanner-headlineSmall">
-        <h2 class="imacBanner-headline">Customer Stories</h2>
-        <span class="imacBanner-line left-top"></span>
-        <span class="imacBanner-line left-bottom"></span>
-        <span class="imacBanner-line right-bottom"></span>
-      </div>
-      <div class="imacBanner-storyLogo">
-        <img class="imacBanner-storyLogoImage" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="Under Armour">
+<div class="contentOffset">
+  <!--Header Short-->
+  <div class="imacBanner imacBanner-stories">
+    <div class="imacBanner-container">
+      <div class="imacBanner-textRow imacBanner-storiesTextRow">
+        <div class="imacBanner-textContainer imacBanner-headlineSmall">
+          <h2 class="imacBanner-headline">Customer Stories</h2>
+          <span class="imacBanner-line left-top"></span>
+          <span class="imacBanner-line left-bottom"></span>
+          <span class="imacBanner-line right-bottom"></span>
+        </div>
+        <div class="imacBanner-storyLogo">
+          <img class="imacBanner-storyLogoImage" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="Under Armour">
+        </div>
       </div>
     </div>
   </div>
+
+  <!-- Story Region -->
+  <div class="container standard-padding">
+    <div class="row">
+      <div class="story-titleWrapper">
+        <h1 class="story-title">Under Armour</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="story-colLeft">
+        <p>A high performance site infrastructure, plus the Fanatical Support service and uptime they required.</p>
+        <p><a href="javascript: void(0);" class="story-caseStudyButton">Read the Case Study</a></p>
+      </div>
+      <div class="story-colRight">
+        <div class="embed-responsive embed-responsive-16by9">
+          <%- partial('../_partials/solutions/video', {'videoId' : 'd_xh7lmCJZs'} ) %>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="story-colLeft">
+        <h2 class="story-subtitle">Business</h2>
+        <p>Under Armour is an American sports clothing and accessories company, headquarter in Baltimore, Maryland.</p>
+
+        <h2 class="story-subtitle">Challenges</h2>
+        <p>Finding a best-in-class hosting provider to host their high-demand Ecommerce and brand experience sites.</p>
+
+        <h2 class="story-subtitle">Solution</h2>
+        <p>
+          <a href="javascript:void(0);">Managed Cloud Servers</a>,
+          <a href="javascript:void(0);">Dedicated Server Clusters</a>,
+          <a href="javascript:void(0);">Firewalls</a>,
+          <a href="javascript:void(0);">Load Balancers</a>,
+          <a href="javascript:void(0);">SAN Storage</a>,
+          <a href="javascript:void(0);">Advanced Monitoring</a>,
+          <a href="javascript:void(0);">Cloud Files</a>
+        </p>
+      </div>
+      <div class="story-colRight">
+        <h2 class="story-subtitle">About the Customer</h2>
+        <p>The company is the developer, marketer, and supplier of a wide range of sportswear and casual apparel mainly focusing on hi-tech sportswear for professional athletes. Under Armour began offering footwear in 2006, and now operates as a global company with offices in Denver, Amsterdam, Denver, Hong Kong, Toronto and Guangzhou, China.</p>
+      </div>
+    </div>
+  </div>
+
+  <%- partial('../_partials/solutions/testimonials') %>
+  <%- partial('../_partials/solutions/cta') %>
+  <%- partial("../_partials/_rug") %>
+  <%- partial("../_partials/_footer") %>
+  <%- partial("../_partials/_basement") %>
 </div>
-
-<!-- Story Region -->
-<div class="container standard-padding">
-  <div class="row">
-    <div class="story-titleWrapper">
-      <h1 class="story-title">Under Armour</h1>
-    </div>
-  </div>
-  <div class="row">
-    <div class="story-colLeft">
-      <p>A high performance site infrastructure, plus the Fanatical Support service and uptime they required.</p>
-      <p><a href="javascript: void(0);" class="story-caseStudyButton">Read the Case Study</a></p>
-    </div>
-    <div class="story-colRight">
-      <div class="embed-responsive embed-responsive-16by9">
-        <%- partial('../_partials/solutions/video', {'videoId' : 'd_xh7lmCJZs'} ) %>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="story-colLeft">
-      <h2 class="story-subtitle">Business</h2>
-      <p>Under Armour is an American sports clothing and accessories company, headquarter in Baltimore, Maryland.</p>
-
-      <h2 class="story-subtitle">Challenges</h2>
-      <p>Finding a best-in-class hosting provider to host their high-demand Ecommerce and brand experience sites.</p>
-
-      <h2 class="story-subtitle">Solution</h2>
-      <p>
-        <a href="javascript:void(0);">Managed Cloud Servers</a>,
-        <a href="javascript:void(0);">Dedicated Server Clusters</a>,
-        <a href="javascript:void(0);">Firewalls</a>,
-        <a href="javascript:void(0);">Load Balancers</a>,
-        <a href="javascript:void(0);">SAN Storage</a>,
-        <a href="javascript:void(0);">Advanced Monitoring</a>,
-        <a href="javascript:void(0);">Cloud Files</a>
-      </p>
-    </div>
-    <div class="story-colRight">
-      <h2 class="story-subtitle">About the Customer</h2>
-      <p>The company is the developer, marketer, and supplier of a wide range of sportswear and casual apparel mainly focusing on hi-tech sportswear for professional athletes. Under Armour began offering footwear in 2006, and now operates as a global company with offices in Denver, Amsterdam, Denver, Hong Kong, Toronto and Guangzhou, China.</p>
-    </div>
-  </div>
-</div>
-
-<%- partial('../_partials/solutions/testimonials') %>
-<%- partial('../_partials/solutions/cta') %>
-<%- partial("../_partials/_rug") %>
-<%- partial("../_partials/_footer") %>
-<%- partial("../_partials/_basement") %>

--- a/styleguide/derek/examples/stories.ejs
+++ b/styleguide/derek/examples/stories.ejs
@@ -8,69 +8,77 @@ var images = [
 
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
+<div class="contentOffset">
 
-<!--Header Short-->
-<div class="imacBanner imacBanner-stories">
-  <div class="imacBanner-container">
-    <div class="imacBanner-textRow">
-      <div class="imacBanner-textContainer imacBanner-headlineSmall">
-        <h2 class="imacBanner-headline">Customer Stories</h2>
-        <span class="imacBanner-line left-top"></span>
-        <span class="imacBanner-line left-bottom"></span>
-        <span class="imacBanner-line right-bottom"></span>
+  <!--Header Short-->
+  <div class="imacBanner imacBanner-stories">
+    <div class="imacBanner-container">
+      <div class="imacBanner-textRow">
+        <div class="imacBanner-textContainer imacBanner-headlineSmall">
+          <h2 class="imacBanner-headline">Customer Stories</h2>
+          <span class="imacBanner-line left-top"></span>
+          <span class="imacBanner-line left-bottom"></span>
+          <span class="imacBanner-line right-bottom"></span>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<!-- Story Region -->
-<div class="container standard-padding">
-  <div class="row">
-    <div class="storyOverview-searchFilter">
-      <div class="storyOverview-searchFilter-label">Find A Story</div>
-      <div class="storyOverview-searchFilter-eventType">
-        <form method="post" action="javascript:void(0);">
-          <select class="storyOverview-searchFilter-select">
-            <option disabled="disabled" selected="selected">Industry</option>
-            <option value="1">All</option>
-            <option value="2">Advertising</option>
-            <option value="3">Agency</option>
-            <option value="4">...</option>
-          </select>
-          <select class="storyOverview-searchFilter-select">
-            <option disabled="disabled" selected="selected">Product</option>
-            <option value="1">All</option>
-            <option value="2">Cloud Backup</option>
-            <option value="3">Cloud Block Storage</option>
-            <option value="4">...</option>
-          </select>
-          <select class="storyOverview-searchFilter-select">
-            <option disabled="disabled" selected="selected">Region</option>
-            <option value="1">All</option>
-            <option value="2">Asia</option>
-            <option value="3">Australia</option>
-            <option value="4">...</option>
-          </select>
-          <input type="submit" class="storyOverview-searchFilter-submit" value="Show Results"/>
-        </form>
+  <!-- Story Region -->
+  <div class="story-container">
+    <div class="row">
+      <div class="storyOverview-searchFilter">
+        <div class="storyOverview-searchFilter-label">Find A Story</div>
+        <div class="storyOverview-searchFilter-eventType">
+          <form method="post" action="javascript:void(0);">
+            <select class="storyOverview-searchFilter-select">
+              <option disabled="disabled" selected="selected">Industry</option>
+              <option value="1">All</option>
+              <option value="2">Advertising</option>
+              <option value="3">Agency</option>
+              <option value="4">...</option>
+            </select>
+            <select class="storyOverview-searchFilter-select">
+              <option disabled="disabled" selected="selected">Product</option>
+              <option value="1">All</option>
+              <option value="2">Cloud Backup</option>
+              <option value="3">Cloud Block Storage</option>
+              <option value="4">...</option>
+            </select>
+            <select class="storyOverview-searchFilter-select">
+              <option disabled="disabled" selected="selected">Region</option>
+              <option value="1">All</option>
+              <option value="2">Asia</option>
+              <option value="3">Australia</option>
+              <option value="4">...</option>
+            </select>
+            <input type="submit" class="storyOverview-searchFilter-submit" value="Show Results"/>
+          </form>
+        </div>
       </div>
-    </div>
-    <div class="storyOverview-searchResults">
-      <% for (var row = 0; row < 4; row++) { %>
-      <div class="row">
-        <% for (var col = 0; col < 3; col++) { %>
-          <div class="storyOverview-item">
-            <div class="storyOverview-itemInner">
-              <a href="/derek/examples/stories-interior" class="storyOverview-logo" style="background-image: url('<%- images[(col + row) % 3] %>');">Under Armour</a>
+      <div class="storyOverview-searchResults">
+        <% for (var row = 0; row < 4; row++) { %>
+        <div class="row">
+          <% for (var col = 0; col < 3; col++) { %>
+            <div class="storyOverview-item">
+              <div class="storyOverview-itemInner">
+                <a href="/derek/examples/stories-interior" class="storyOverview-itemLink">
+                  <% if ((col + row) % 4 === 3) { %>
+                  <span class="storyOverview-logoText">Company Name That Spans Multiple Lines</span>
+                  <% } else { %>
+                  <img class="storyOverview-logo" src="<%- images[(col + row) % 3] %>" alt="Under Armour">
+                  <% } %>
+                </a>
+              </div>
             </div>
-          </div>
+          <% } %>
+        </div>
         <% } %>
       </div>
-      <% } %>
     </div>
   </div>
-</div>
 
-<%- partial("../_partials/_rug") %>
-<%- partial("../_partials/_footer") %>
-<%- partial("../_partials/_basement") %>
+  <%- partial("../_partials/_rug") %>
+  <%- partial("../_partials/_footer") %>
+  <%- partial("../_partials/_basement") %>
+</div>


### PR DESCRIPTION
The previous version of the stories overview page only allowed for image-based logos, but we're not going to have logos for everything, so we need a text fail-over option. Due to vertical-alignment concerns, it required a bit of refactoring, and I opted to use the `<img>` tag instead of background images. 

http://localhost:9000/derek/examples/stories