### PR TITLE
RSWEB-7625: add height auto to image content type

### DIFF
--- a/styleguide/_themes/derek/scss/_main.scss
+++ b/styleguide/_themes/derek/scss/_main.scss
@@ -12,6 +12,7 @@
 @import 'components/ticker';
 @import 'patterns/announcements';
 @import 'patterns/blog-feed';
+@import 'patterns/image';
 @import 'patterns/lead';
 @import 'patterns/quote';
 @import 'patterns/videoEmbed';

--- a/styleguide/_themes/derek/scss/patterns/image.scss
+++ b/styleguide/_themes/derek/scss/patterns/image.scss
@@ -1,0 +1,6 @@
+.image-wrapper {
+  img {
+    height: auto;
+    width: auto;
+  }
+}


### PR DESCRIPTION
Adds `height: auto;` for image content type. 

Corresponding www PR - https://github.rackspace.com/rswebteam/www/pull/1363
