### PR TITLE
refactor(rsweb-7637-remove-hp-inline-styles): remove solutions class

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/homepage.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/homepage.scss
@@ -153,9 +153,6 @@
 
 
 //solutions
-.solutions {
-  padding: $standard-padding;
-}
 
 .solutions-hoverArea {
   text-decoration: none;


### PR DESCRIPTION
This PR removed the the solutions declaration that allows us to remove all inline style blocks from the home page. 