### PR TITLE
chore(rsweb-7086-sass-lint-color-literals): remove color functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:visual:init": "nohup npm start & (cd ./node_modules/backstopjs && npm run reference)",
     "backstop-update": "node ./scripts/update-backstop-urls.js",
     "sass:compile": "node-sass --output-style=compressed --quiet -o /tmp styleguide/css",
-    "sass-lint": "sass-lint -v --max-warnings 45",
+    "sass-lint": "sass-lint -v --max-warnings 38",
     "hooks": "./scripts/hooks.sh",
     "postinstall": "npm run hooks"
   },

--- a/styleguide/_themes/derek/scss/globalElements/ceilingLp.scss
+++ b/styleguide/_themes/derek/scss/globalElements/ceilingLp.scss
@@ -1,7 +1,7 @@
 .ceilingLp {
   background: $white;
   border-bottom: 1px solid $gray-lighter;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+  box-shadow: 0 6px 12px $black-shadow;
 }
 
 .ceilingLp-brand {

--- a/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
@@ -16,7 +16,7 @@
 .businessResource-widget-hover {
   &:hover {
     background-color: $blue-steel;
-    border-top: 12px solid rgba(0, 0, 0, .4);
+    border-top: 12px solid darken($blue-steel, 20);
     text-decoration: none;
 
     h3,

--- a/styleguide/_themes/derek/scss/patterns/cards/modules.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/modules.scss
@@ -25,7 +25,6 @@
     vertical-align: middle;
 
     &:hover {
-      background-color: rgba(0, 5, 10, .1);
       cursor: pointer;
     }
   }
@@ -73,7 +72,7 @@
 
   span {
     &:hover {
-      background-color: rgba(0, 5, 10, .1);
+      background-color: $blue-steel;
       cursor: pointer;
     }
   }

--- a/styleguide/_themes/global/scss/forms.scss
+++ b/styleguide/_themes/global/scss/forms.scss
@@ -41,7 +41,7 @@ table {
   }
 
   .form-control {
-    background-color: rgba(235, 0, 34, .1);
+    background-color: lighten($brand-danger, 10);
     border-color: $brand-danger;
   }
 }
@@ -64,7 +64,7 @@ table {
   }
 
   .form-control {
-    background-color: rgba(0, 133, 0, .1);
+    background-color: lighten($brand-success, 10);
     border-color: $brand-success;
   }
 }
@@ -89,7 +89,7 @@ table {
   }
 
   .form-control {
-    background-color: rgba(235, 104, 0, .1);
+    background-color: lighten($brand-warning, 10);
     border-color: $brand-warning;
   }
 }

--- a/styleguide/_themes/global/scss/swatch.scss
+++ b/styleguide/_themes/global/scss/swatch.scss
@@ -31,3 +31,6 @@ $brand-secondary:   $teal-medium   !default;
 $brand-success:     $signup-green  !default;
 $brand-warning:     $orange        !default;
 $brand-danger:      $rackspace-red !default;
+
+//alpha colors
+$black-shadow:		rgba($black, .175);


### PR DESCRIPTION
This PR removes color functions from properties and creates a black-shadow variable to be used globally for elements that contain drop shadows. 
