### PR TITLE
RSWEB-7648: add contentOffset to example pages

### DIFF
--- a/styleguide/derek/examples/events-interior.ejs
+++ b/styleguide/derek/examples/events-interior.ejs
@@ -1,74 +1,74 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
-
-<!--Header Large-->
-<div class="events-banner">
-  <div class="events-bannerRow">
-    <div class="events-bannerCol">
-      <div class="events-bannerTitle">Rackspace Events Calendar</div>
+<div class="contentOffset">
+  <!--Header Large-->
+  <div class="events-banner">
+    <div class="events-bannerRow">
+      <div class="events-bannerCol">
+        <div class="events-bannerTitle">Rackspace Events Calendar</div>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="bg-light-gray">
-  <div class="event">
-    <div class="event-row">
-      <div class="event-date">
-        <div class="event-dateBox">
-          <div class="event-dateBox-month">July</div>
-          <div class="event-dateBox-day">24</div>
-          <div class="event-dateBox-year">2016</div>
-        </div>
-      </div>
-      <div class="event-info">
-        <div class="event-info-header">
-          <h1 class="event-info-headerTitle">
-            Rackspace::Solve San Francisco
-          </h1>
-          <div class="event-info-headerType">
-            Tradeshow/Conference
+  <div class="bg-light-gray">
+    <div class="event">
+      <div class="event-row">
+        <div class="event-date">
+          <div class="event-dateBox">
+            <div class="event-dateBox-month">July</div>
+            <div class="event-dateBox-day">24</div>
+            <div class="event-dateBox-year">2016</div>
           </div>
         </div>
-        <div class="event-info-whereWhen">
-          <div class="event-info-where">
-            <div class="event-info-whereTitle">
-              Where
-            </div>
-            <div class="event-info-whereAddress">
-              Four Seasons<br />
-              757 Market St<br />
-              San Francisco, California 94103
+        <div class="event-info">
+          <div class="event-info-header">
+            <h1 class="event-info-headerTitle">
+              Rackspace::Solve San Francisco
+            </h1>
+            <div class="event-info-headerType">
+              Tradeshow/Conference
             </div>
           </div>
-          <div class="event-info-when">
-            <div class="event-info-whenTitle">
-              When
+          <div class="event-info-whereWhen">
+            <div class="event-info-where">
+              <div class="event-info-whereTitle">
+                Where
+              </div>
+              <div class="event-info-whereAddress">
+                Four Seasons<br />
+                757 Market St<br />
+                San Francisco, California 94103
+              </div>
             </div>
-            <div class="event-info-whenDateTime">
-              July 24-July 26<br />
-              8:00am-6:00pm
+            <div class="event-info-when">
+              <div class="event-info-whenTitle">
+                When
+              </div>
+              <div class="event-info-whenDateTime">
+                July 24-July 26<br />
+                8:00am-6:00pm
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="event-row">
-      <div class="event-map">
-        <img class="event-mapCanvas" src="/imgs/derek/examples/event-map.jpg" alt="[map]" />
+      <div class="event-row">
+        <div class="event-map">
+          <img class="event-mapCanvas" src="/imgs/derek/examples/event-map.jpg" alt="[map]" />
+        </div>
+        <div class="event-details">
+          <div class="event-detailsTitle">Details</div>
+          <p>Join us at Rackspace::Solve San Francisco, a free conference where you’ll learn how the latest cloud solutions can help you scale your business, get your products to market quickly, and reduce the cost of innovation.</p>
+          <p>Sessions cover real world solutions to cloud security, big data, and private cloud challenges. Visit our Solutions Pavilion to discuss your company’s specific needs and whiteboard solutions with Rackspace experts and partners.</p>
+          <p>Beyond empowering companies to tap into the power of the cloud, Rackspace also strives for social empowerment. In that spirit, we’ll make a monetary donation of $15 per attendee to Girls Who Code – up to $5,000. In addition to a great day of learning and networking, your attendance at Rackspace::Solve will help give high school girls the skills and resources they need to pursue opportunities in computing fields.</p>
+        </div>
       </div>
-      <div class="event-details">
-        <div class="event-detailsTitle">Details</div>
-        <p>Join us at Rackspace::Solve San Francisco, a free conference where you’ll learn how the latest cloud solutions can help you scale your business, get your products to market quickly, and reduce the cost of innovation.</p>
-        <p>Sessions cover real world solutions to cloud security, big data, and private cloud challenges. Visit our Solutions Pavilion to discuss your company’s specific needs and whiteboard solutions with Rackspace experts and partners.</p>
-        <p>Beyond empowering companies to tap into the power of the cloud, Rackspace also strives for social empowerment. In that spirit, we’ll make a monetary donation of $15 per attendee to Girls Who Code – up to $5,000. In addition to a great day of learning and networking, your attendance at Rackspace::Solve will help give high school girls the skills and resources they need to pursue opportunities in computing fields.</p>
+      <div class="event-row">
+        <a class="event-backToEvents" href="/derek/examples/events">Back to upcoming events</a>
       </div>
-    </div>
-    <div class="event-row">
-      <a class="event-backToEvents" href="/derek/examples/events">Back to upcoming events</a>
     </div>
   </div>
-</div>
-
 <%- partial("../_partials/_rug") %>
 <%- partial("../_partials/_footer") %>
 <%- partial("../_partials/_basement") %>
+</div>

--- a/styleguide/derek/examples/events.ejs
+++ b/styleguide/derek/examples/events.ejs
@@ -1,68 +1,69 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
-
-<!--Header Large-->
-<div class="events-banner">
-  <div class="events-bannerRow">
-    <div class="events-bannerCol">
-      <h1 class="events-bannerTitle">Rackspace Events Calendar</h1>
+<div class="contentOffset">
+  <!--Header Large-->
+  <div class="events-banner">
+    <div class="events-bannerRow">
+      <div class="events-bannerCol">
+        <h1 class="events-bannerTitle">Rackspace Events Calendar</h1>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="bg-light-gray">
-  <div class="eventsOverview">
-    <div class="eventsOverview-row">
-      <div class="eventsOverview-searchFilter">
-        <div class="eventsOverview-searchFilter-label">Find An Event</div>
-        <div class="eventsOverview-searchFilter-eventType">
-          <form method="post" action="javascript:void(0);">
-            <select class="eventsOverview-searchFilter-eventTypeSelect">
-              <option disabled="disabled" selected="selected">Event Type</option>
-              <option value="1">All</option>
-              <option value="2">Customer Events</option>
-              <option value="3">Field Events</option>
-              <option value="4">Forum</option>
-              <option value="5">Tradeshow/Conference</option>
-              <option value="6">Training</option>
-              <option value="7">Webinar</option>
-            </select>
-            <input type="submit" class="eventsOverview-searchFilter-eventTypeSubmit" value="Show Results"/>
-          </form>
+  <div class="bg-light-gray">
+    <div class="eventsOverview">
+      <div class="eventsOverview-row">
+        <div class="eventsOverview-searchFilter">
+          <div class="eventsOverview-searchFilter-label">Find An Event</div>
+          <div class="eventsOverview-searchFilter-eventType">
+            <form method="post" action="javascript:void(0);">
+              <select class="eventsOverview-searchFilter-eventTypeSelect">
+                <option disabled="disabled" selected="selected">Event Type</option>
+                <option value="1">All</option>
+                <option value="2">Customer Events</option>
+                <option value="3">Field Events</option>
+                <option value="4">Forum</option>
+                <option value="5">Tradeshow/Conference</option>
+                <option value="6">Training</option>
+                <option value="7">Webinar</option>
+              </select>
+              <input type="submit" class="eventsOverview-searchFilter-eventTypeSubmit" value="Show Results"/>
+            </form>
+          </div>
+        </div>
+        <div class="eventsOverview-searchResults">
+          <% for(var i = 0; i < 4; i++) { %>
+            <div class="eventsOverview-weekTitle">
+              Week of September <%= i * 7 + 1 %>, 2016
+            </div>
+            <% for(var j = i; j < i + i % 3 + 1; j++) { %>
+              <div class="eventsOverview-weekEvent">
+                <div class="eventsOverview-weekEvent-header">
+                  <div class="eventsOverview-weekEvent-headerTitle">Rackspace::Solve San Francisco</div>
+                  <div class="eventsOverview-weekEvent-headerLocation">San Francisco, CA</div>
+                </div>
+                <div class="eventsOverview-weekEvent-date">September <%= i * 7 + 1 + j %>, 2016</div>
+                <div class="eventsOverview-weekEvent-details">
+                  Andouille corned beef pig doner. Jowl frankfurter ball tip flank short loin short ribs. Tri-tip prosciutto leberkas capicola pork belly fatback meatball, biltong venison jerky hamburger picanha. Corned beef turducken tongue ribeye, shankle salami boudin. Boudin doner shankle t-bone ball tip short loin tongue short ribs ham.
+                </div>
+                <a class="eventsOverview-weekEvent-learnMore" href="/derek/examples/events-interior">Learn More</a>
+              </div>
+            <% } %>
+          <% } %>
+          <ul class="eventsOverview-pagination">
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPagePrev" href="javascript:void(0)">&lt;</a></li>
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">1</a></li>
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageActive" href="javascript:void(0)">2</a></li>
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">3</a></li>
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">4</a></li>
+            <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageNext" href="javascript:void(0)">&gt;</a></li>
+          </ul>
         </div>
       </div>
-      <div class="eventsOverview-searchResults">
-        <% for(var i = 0; i < 4; i++) { %>
-          <div class="eventsOverview-weekTitle">
-            Week of September <%= i * 7 + 1 %>, 2016
-          </div>
-          <% for(var j = i; j < i + i % 3 + 1; j++) { %>
-            <div class="eventsOverview-weekEvent">
-              <div class="eventsOverview-weekEvent-header">
-                <div class="eventsOverview-weekEvent-headerTitle">Rackspace::Solve San Francisco</div>
-                <div class="eventsOverview-weekEvent-headerLocation">San Francisco, CA</div>
-              </div>
-              <div class="eventsOverview-weekEvent-date">September <%= i * 7 + 1 + j %>, 2016</div>
-              <div class="eventsOverview-weekEvent-details">
-                Andouille corned beef pig doner. Jowl frankfurter ball tip flank short loin short ribs. Tri-tip prosciutto leberkas capicola pork belly fatback meatball, biltong venison jerky hamburger picanha. Corned beef turducken tongue ribeye, shankle salami boudin. Boudin doner shankle t-bone ball tip short loin tongue short ribs ham.
-              </div>
-              <a class="eventsOverview-weekEvent-learnMore" href="/derek/examples/events-interior">Learn More</a>
-            </div>
-          <% } %>
-        <% } %>
-        <ul class="eventsOverview-pagination">
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPagePrev" href="javascript:void(0)">&lt;</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">1</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageActive" href="javascript:void(0)">2</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">3</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">4</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageNext" href="javascript:void(0)">&gt;</a></li>
-        </ul>
-      </div>
     </div>
   </div>
-</div>
 
 <%- partial("../_partials/_rug") %>
 <%- partial("../_partials/_footer") %>
 <%- partial("../_partials/_basement") %>
+</div>

--- a/styleguide/derek/examples/homepage.ejs
+++ b/styleguide/derek/examples/homepage.ejs
@@ -1,257 +1,259 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
+<div class="contentOffset">
 <%- partial("../_partials/solutions/header-largeIMAC.ejs") %>
-
-<!-- Hosting Options -->
-<div class="container standard-padding hostingOptions">
-	<div class="row half-padding-full">
-		<div class="col-md-11 center-block">
-			<h2 class="center">We're the largest managed cloud provider, offering you expertise across the world's leading clouds</h2>
-		</div>
-	</div>
-	<div class="hostingOptions-productRow">
-	  <div class="clear-container panel-flex">
-		<div class="product hostingOptions-product">
-			<a href="/dedicated-servers" class="hostingOptions-hoverArea">
-				<div class="hostingOptions-logoRow">
-					<div class="hostingOptions-logo">
-						<img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/dedicatedOutline.svg" style="padding-top:9px;">
-					</div>
-				</div>
-				<div class="hostingOptions-titleRow">
-				  <h3 class="hostingOptions-title">Dedicated<br/>Hosting</h3>
-					<div class="hostingOptions-hrContainer">
-						<hr class="hostingOptions-hr">
-					</div>
-					<div class="hostingOptions-textContainer" style="margin-bottom:20px">
-						<p class="hostingOptions-text">More than 3,000 hosting engineers across Linux, Windows and VMware</p>
-					</div>
-				</div>
-				<div class="hostingOptions-learnMoreBottom">
-          <a href="/dedicated-servers" class="hostingOptions-learnMore">Learn More</a>
-			  </div>
-			</a>
-		</div>
-		<div class="product hostingOptions-product">
-			<a href="/managed-aws" class="hostingOptions-hoverArea">
-				<div class="hostingOptions-logoRow">
-					<div class="hostingOptions-logoWide">
-						<img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/amazonPartner.png">
-					</div>
-				</div>
-				<div class="hostingOptions-titleRow">
-				  <h3 class="hostingOptions-title">Amazon Web<br/>Services</h3>
-					<div class="hostingOptions-hrContainer">
-						<hr class="hostingOptions-hr">
-					</div>
-					<div class="hostingOptions-textContainer">
-						<p class="hostingOptions-text">[aws:aws-cert-number] AWS certified professionals, supporting all 11 AWS public regions</p>
-					</div>
-				</div>
-				<div class="hostingOptions-learnMoreBottom">
-          <a href="/managed-aws" class="hostingOptions-learnMore">Learn More</a>
-			  </div>
-			</a>
-		</div>
-</div>
-<div class="clear-container panel-flex">
-		<div class="product hostingOptions-product">
-			<a href="/microsoft" class="hostingOptions-hoverArea">
-				<div class="hostingOptions-logoRow">
-					<div class="hostingOptions-logoWide">
-						<img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/Microsoft2.svg">
-					</div>
-				</div>
-				<div class="hostingOptions-titleRow">
-				  <h3 class="hostingOptions-title">Microsoft<br/> Cloud / Azure</h3>
-					<div class="hostingOptions-hrContainer">
-						<hr class="hostingOptions-hr">
-					</div>
-					<div class="hostingOptions-textContainer">
-						<p class="hostingOptions-text">5-time Microsoft Hosting Partner of the Year — only multi-year winner</p>
-					</div>
-				</div>
-				<div class="hostingOptions-learnMoreBottom">
-          <a href="/microsoft" class="hostingOptions-learnMore">Learn More</a>
-			  </div>
-			</a>
-		</div>
-		<div class="product hostingOptions-product">
-			<a href="/openstack" class="hostingOptions-hoverArea">
-				<div class="hostingOptions-logoRow">
-					<div class="hostingOptions-logo">
-						<img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/openstack.svg" style="padding-top:9px;">
-					</div>
-				</div>
-				<div class="hostingOptions-titleRow">
-				  <h3 class="hostingOptions-title">Openstack<br/>Cloud</h3>
-					<div class="hostingOptions-hrContainer">
-						<hr class="hostingOptions-hr">
-					</div>
-					<div class="hostingOptions-textContainer">
-						<p class="hostingOptions-text">Co-founder with NASA; the most experience in the world by 100-times</p>
-					</div>
-				</div>
-				<div class="hostingOptions-learnMoreBottom">
-          <a href="/cloud/openstack" class="hostingOptions-learnMore">Learn More</a>
-			  </div>
-       </a>
-		</div>
-		</div>
-	</div>
-</div>
-
-
-<!-- Business Size -->
-<div class="bg-blue-gray">
-  <div class="container solutions" id="solutions">
-    <div class="row">
-      <div class="col-md-10 center-block">
-        <h2 class="white center">Whether you're a big
-  enterprise or a small business, we have solutions just for you </h2>
-        <p class="white center">Let our experts help you devise the best solution to meet your needs. Select the relevant area to learn more. </p>
-      </div>
-    </div>
+  <!-- Hosting Options -->
+  <div class="container standard-padding hostingOptions">
     <div class="row half-padding-full">
       <div class="col-md-11 center-block">
-      <a href="[rs_link:managed-security]" class="solution solutions-hoverArea">
-          <div class="col-md-2 col-md-push-1 col-xs-4">
-              <div class="border-white center">
-                <i class="rsweb mng-security white rs-4x"></i>
-              </div>
-            <h6 class="white center">Managed Security</h6>
-          </div>
-        </a>
-        <a href="[rs_link:website-hosting]" class="solution solutions-hoverArea">
-          <div class="col-md-2 col-md-push-1 col-xs-4">
-              <div class="border-white center">
-                <i class="rsweb srv-web-hosting white rs-4x"></i>
-              </div>
-            <h6 class="white center">Website Hosting</h6>
-          </div>
-        </a>
-        <a href="[rs_link:ecommerce]" class="solution solutions-hoverArea">
-          <div class="col-md-2 col-md-push-1 col-xs-4">
-              <div class="border-white center">
-                <i class="rsweb srv-ecommerce white rs-4x"></i>
-              </div>
-            <h6 class="white center">Ecommerce <br/>Solutions</h6>
-          </div>
-        </a>
-        <a href="[rs_link:data]" class="solution solutions-hoverArea">
-          <div class="col-md-2 col-md-push-1 col-xs-4">
-              <div class="border-white center">
-                <i class="rsweb mng-databases white rs-4x"></i>
-              </div>
-            <h6 class="white center">Managed Databases</h6>
-          </div>
-        </a>
-        <a href="[rs_link:email-hosting]" class="solution solutions-hoverArea">
-          <div class="col-md-2 col-md-push-1 col-xs-4">
-              <div class="border-white center">
-                <i class="rsweb srv-email white rs-4x"></i>
-              </div>
-            <h6 class="white center">Email <br/>Hosting</h6>
-          </div>
-        </a>
+        <h2 class="center">We're the largest managed cloud provider, offering you expertise across the world's leading clouds</h2>
       </div>
     </div>
-  </div>
-</div>
-
-
-<!-- Quadrant -->
-<div class="container-fluid quadrant" id="quadrant">
-  <div class="container">
-    <div class="quadrant-row">
-      <div class="quadrant-textContainer">
-        <h2 class="quadrant-title">Fanatical Support wherever you are, day or night, we have you covered 24x7x365</h2>
-        <p class="quadrant-text">We're more than just a hosting provider - we're your trusted service partner, and we're ready to help solve the toughest problems. Gartner has recognized us as a leader in their <a href="[rsweb:about:cloud-enabled]">Magic Quadrant for Cloud Enabled Managed Hosting.</a></p>
-          <div class="quadrant-buttonContainer">
-            <a class="button learning" href="[rsweb:why-rackspace]">Learn More</a>
-          </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<!-- Testimonials -->
-<div class="bg-steel-blue standard-padding">
-  <div class="container">
-    <div id="quote">
-      <div class="row">
-        <div class="col-md-12">
-          <h2 class="white center">
-            Trusted By The Brands You Know
-          </h2>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12">
-          <div class="row">
-            <div class="col-md-8 center-block">
-              <blockquote class="center white">Because of Fanatical Support, we knew we were partnering with a best-in-class company that shared our vision of getting it done.</blockquote>
-              <cite class="center">Brian McManus, Senior Director of Technology - Under Armour</cite>
+    <div class="hostingOptions-productRow">
+      <div class="clear-container panel-flex">
+      <div class="product hostingOptions-product">
+        <a href="/dedicated-servers" class="hostingOptions-hoverArea">
+          <div class="hostingOptions-logoRow">
+            <div class="hostingOptions-logo">
+              <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/dedicatedOutline.svg" style="padding-top:9px;">
             </div>
           </div>
-          <!--Option for logo-->
-          <div class="row read-more">
-            <div class="col-md-1 col-xs-2 center-block">
-              <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="">
+          <div class="hostingOptions-titleRow">
+            <h3 class="hostingOptions-title">Dedicated<br/>Hosting</h3>
+            <div class="hostingOptions-hrContainer">
+              <hr class="hostingOptions-hr">
+            </div>
+            <div class="hostingOptions-textContainer" style="margin-bottom:20px">
+              <p class="hostingOptions-text">More than 3,000 hosting engineers across Linux, Windows and VMware</p>
+            </div>
+          </div>
+          <div class="hostingOptions-learnMoreBottom">
+            <a href="/dedicated-servers" class="hostingOptions-learnMore">Learn More</a>
+          </div>
+        </a>
+      </div>
+      <div class="product hostingOptions-product">
+        <a href="/managed-aws" class="hostingOptions-hoverArea">
+          <div class="hostingOptions-logoRow">
+            <div class="hostingOptions-logoWide">
+              <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/amazonPartner.png">
+            </div>
+          </div>
+          <div class="hostingOptions-titleRow">
+            <h3 class="hostingOptions-title">Amazon Web<br/>Services</h3>
+            <div class="hostingOptions-hrContainer">
+              <hr class="hostingOptions-hr">
+            </div>
+            <div class="hostingOptions-textContainer">
+              <p class="hostingOptions-text">[aws:aws-cert-number] AWS certified professionals, supporting all 11 AWS public regions</p>
+            </div>
+          </div>
+          <div class="hostingOptions-learnMoreBottom">
+            <a href="/managed-aws" class="hostingOptions-learnMore">Learn More</a>
+          </div>
+        </a>
+      </div>
+  </div>
+  <div class="clear-container panel-flex">
+      <div class="product hostingOptions-product">
+        <a href="/microsoft" class="hostingOptions-hoverArea">
+          <div class="hostingOptions-logoRow">
+            <div class="hostingOptions-logoWide">
+              <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/Microsoft2.svg">
+            </div>
+          </div>
+          <div class="hostingOptions-titleRow">
+            <h3 class="hostingOptions-title">Microsoft<br/> Cloud / Azure</h3>
+            <div class="hostingOptions-hrContainer">
+              <hr class="hostingOptions-hr">
+            </div>
+            <div class="hostingOptions-textContainer">
+              <p class="hostingOptions-text">5-time Microsoft Hosting Partner of the Year — only multi-year winner</p>
+            </div>
+          </div>
+          <div class="hostingOptions-learnMoreBottom">
+            <a href="/microsoft" class="hostingOptions-learnMore">Learn More</a>
+          </div>
+        </a>
+      </div>
+      <div class="product hostingOptions-product">
+        <a href="/openstack" class="hostingOptions-hoverArea">
+          <div class="hostingOptions-logoRow">
+            <div class="hostingOptions-logo">
+              <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/openstack.svg" style="padding-top:9px;">
+            </div>
+          </div>
+          <div class="hostingOptions-titleRow">
+            <h3 class="hostingOptions-title">Openstack<br/>Cloud</h3>
+            <div class="hostingOptions-hrContainer">
+              <hr class="hostingOptions-hr">
+            </div>
+            <div class="hostingOptions-textContainer">
+              <p class="hostingOptions-text">Co-founder with NASA; the most experience in the world by 100-times</p>
+            </div>
+          </div>
+          <div class="hostingOptions-learnMoreBottom">
+            <a href="/cloud/openstack" class="hostingOptions-learnMore">Learn More</a>
+          </div>
+         </a>
+      </div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- Business Size -->
+  <div class="bg-blue-gray">
+    <div class="container solutions" id="solutions">
+      <div class="row">
+        <div class="col-md-10 center-block">
+          <h2 class="white center">Whether you're a big
+    enterprise or a small business, we have solutions just for you </h2>
+          <p class="white center">Let our experts help you devise the best solution to meet your needs. Select the relevant area to learn more. </p>
+        </div>
+      </div>
+      <div class="row half-padding-full">
+        <div class="col-md-11 center-block">
+        <a href="[rs_link:managed-security]" class="solution solutions-hoverArea">
+            <div class="col-md-2 col-md-push-1 col-xs-4">
+                <div class="border-white center">
+                  <i class="rsweb mng-security white rs-4x"></i>
+                </div>
+              <h6 class="white center">Managed Security</h6>
+            </div>
+          </a>
+          <a href="[rs_link:website-hosting]" class="solution solutions-hoverArea">
+            <div class="col-md-2 col-md-push-1 col-xs-4">
+                <div class="border-white center">
+                  <i class="rsweb srv-web-hosting white rs-4x"></i>
+                </div>
+              <h6 class="white center">Website Hosting</h6>
+            </div>
+          </a>
+          <a href="[rs_link:ecommerce]" class="solution solutions-hoverArea">
+            <div class="col-md-2 col-md-push-1 col-xs-4">
+                <div class="border-white center">
+                  <i class="rsweb srv-ecommerce white rs-4x"></i>
+                </div>
+              <h6 class="white center">Ecommerce <br/>Solutions</h6>
+            </div>
+          </a>
+          <a href="[rs_link:data]" class="solution solutions-hoverArea">
+            <div class="col-md-2 col-md-push-1 col-xs-4">
+                <div class="border-white center">
+                  <i class="rsweb mng-databases white rs-4x"></i>
+                </div>
+              <h6 class="white center">Managed Databases</h6>
+            </div>
+          </a>
+          <a href="[rs_link:email-hosting]" class="solution solutions-hoverArea">
+            <div class="col-md-2 col-md-push-1 col-xs-4">
+                <div class="border-white center">
+                  <i class="rsweb srv-email white rs-4x"></i>
+                </div>
+              <h6 class="white center">Email <br/>Hosting</h6>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- Quadrant -->
+  <div class="container-fluid quadrant" id="quadrant">
+    <div class="container">
+      <div class="quadrant-row">
+        <div class="quadrant-textContainer">
+          <h2 class="quadrant-title">Fanatical Support wherever you are, day or night, we have you covered 24x7x365</h2>
+          <p class="quadrant-text">We're more than just a hosting provider - we're your trusted service partner, and we're ready to help solve the toughest problems. Gartner has recognized us as a leader in their <a href="[rsweb:about:cloud-enabled]">Magic Quadrant for Cloud Enabled Managed Hosting.</a></p>
+            <div class="quadrant-buttonContainer">
+              <a class="button learning" href="[rsweb:why-rackspace]">Learn More</a>
+            </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+
+  <!-- Testimonials -->
+  <div class="bg-steel-blue standard-padding">
+    <div class="container">
+      <div id="quote">
+        <div class="row">
+          <div class="col-md-12">
+            <h2 class="white center">
+              Trusted By The Brands You Know
+            </h2>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+            <div class="row">
+              <div class="col-md-8 center-block">
+                <blockquote class="center white">Because of Fanatical Support, we knew we were partnering with a best-in-class company that shared our vision of getting it done.</blockquote>
+                <cite class="center">Brian McManus, Senior Director of Technology - Under Armour</cite>
+              </div>
+            </div>
+            <!--Option for logo-->
+            <div class="row read-more">
+              <div class="col-md-1 col-xs-2 center-block">
+                <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="">
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<!-- logo river -->
-<div class="container-fluid half-padding bg-steel-blue">
-  <div class="container logoShowcase">
-    <ul class="logoShowcase-row">
-      <li class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="">
-      </li>
-      <li class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/redhat.png" alt=""/>
-      </li>
-      <li class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/yeti-logoNew.png"/>
-      </li>
-      <li class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/rip-curl-logo.png"/>
-      </li>
-      <li class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/six-flags-logo.png"/>
-      </li>
-      <li  class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/ksLogo.png"/>
-      </li>
-      <li  class="logoShowcase-logoItem">
-        <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/razorfish-logo.png"/>
-      </li>
-    </div>
-  </div>
-</div>
-
-
-
-<!-- Contact River -->
-<div class="container-fluid standard-padding bg-light-gray">
-  <div class="container">
-    <div class="row half-padding">
-      <div class="col-md-8 center-block">
-        <h2 class="center">Get Free Advice From Our Experts</h2>
-        <h5 class="center">We've got your back 24x7x365.</h5>
-        <div class="col-sm-2 center-block">
-          <i class="rsweb gen-support center"></i>
-        </div>
-
+  <!-- logo river -->
+  <div class="container-fluid half-padding bg-steel-blue">
+    <div class="container logoShowcase">
+      <ul class="logoShowcase-row">
+        <li class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/underarmor.png" alt="">
+        </li>
+        <li class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/redhat.png" alt=""/>
+        </li>
+        <li class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/yeti-logoNew.png"/>
+        </li>
+        <li class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/rip-curl-logo.png"/>
+        </li>
+        <li class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/six-flags-logo.png"/>
+        </li>
+        <li  class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/ksLogo.png"/>
+        </li>
+        <li  class="logoShowcase-logoItem">
+          <img class="logoShowcase-image" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/razorfish-logo.png"/>
+        </li>
       </div>
     </div>
   </div>
+
+
+
+  <!-- Contact River -->
+  <div class="container-fluid standard-padding bg-light-gray">
+    <div class="container">
+      <div class="row half-padding">
+        <div class="col-md-8 center-block">
+          <h2 class="center">Get Free Advice From Our Experts</h2>
+          <h5 class="center">We've got your back 24x7x365.</h5>
+          <div class="col-sm-2 center-block">
+            <i class="rsweb gen-support center"></i>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/styleguide/derek/examples/office365.ejs
+++ b/styleguide/derek/examples/office365.ejs
@@ -1,784 +1,609 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
-
-<!--Header Large-->
-<div class="container-fluid banner large outlook">
-  <div class="row">
-    <div class="col-sm-5 center-block">
-      <div class="banner-text">
-        <h1 class="center white">Fanatical Support for Office 365</h1>
-        <p class="center white">All the power of Office 365. None of the frustration of migration and management. We help you get the most out of Office 365. </p>
+<div class="contentOffset">
+  <!--Header Large-->
+  <div class="container-fluid banner large outlook">
+    <div class="row">
+      <div class="col-sm-5 center-block">
+        <div class="banner-text">
+          <h1 class="center white">Fanatical Support for Office 365</h1>
+          <p class="center white">All the power of Office 365. None of the frustration of migration and management. We help you get the most out of Office 365. </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-4 center-block">
-      <a class="button learning strong">Choose A Plan</a>
-    </div>
-  </div>
-</div>
-
-<!--Subnav-->
-<%- partial("../_partials/solutions/subnav") %>
-
-<!-- main content wrap -->
-<div id="content-wrap" class="styleguide">
-  <!-- Lead pattern -->
-  <div class="container">
     <div class="row">
-      <div class="col-md-8 center-block">
-        <h2 class="center">If Office 365 is the rocket,<br/> Fanatical Support is the fuel. </h2>
-        <p class="center">Get support with a human touch from a team of always-available Office 365 specialists. We’re ready to handle any question or issue, no matter how big or small.</p>
+      <div class="col-sm-4 center-block">
+        <a class="button learning strong">Choose A Plan</a>
       </div>
     </div>
   </div>
 
-  <!-- Value Prop section-->
-  <div class="container value-prop-container rocket standard-padding">
-    <div class="row">
-      <div class="col-md-4 col-sm-6">
-        <div class="value-prop">
-          <div class="col-md-5 col-sm-6 col-xs-5 center-block">
+  <!--Subnav-->
+  <%- partial("../_partials/solutions/subnav") %>
+
+  <!-- main content wrap -->
+  <div id="content-wrap" class="styleguide">
+    <!-- Lead pattern -->
+    <div class="container">
+      <div class="row">
+        <div class="col-md-8 center-block">
+          <h2 class="center">If Office 365 is the rocket,<br/> Fanatical Support is the fuel. </h2>
+          <p class="center">Get support with a human touch from a team of always-available Office 365 specialists. We’re ready to handle any question or issue, no matter how big or small.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Value Prop section-->
+    <div class="container value-prop-container rocket standard-padding">
+      <div class="row">
+        <div class="col-md-4 col-sm-6">
+          <div class="value-prop">
+            <div class="col-md-5 col-sm-6 col-xs-5 center-block">
+              <br class="hidden-sm hidden-xs"/>
+              <br class="hidden-sm hidden-xs"/>
+              <i class="rsweb idio-brain circle"></i>
+            </div>
+            <h3 class="center">Access to Experts</h3>
+            <p class="center">We help over 4 million email and productivity users worldwide every day. Now we’re ready to help you get the most out of your investment.</p>
+          </div>
+        </div>
+        <div class="col-md-4 col-sm-6">
+          <div class="value-prop">
+            <div class="col-md-5 col-sm-6 col-xs-5 center-block">
+              <i class="rsweb mng-24x7 circle"></i>
+            </div>
             <br class="hidden-sm hidden-xs"/>
             <br class="hidden-sm hidden-xs"/>
-            <i class="rsweb idio-brain circle"></i>
+            <h3 class="center">24x7x365 Fanatical Support</h3>
+            <p class="center">Receive unlimited, award-winning,  U.S.-based support by phone, chat and email with no per-incident charges.</p>
+            </div>
           </div>
-          <h3 class="center">Access to Experts</h3>
-          <p class="center">We help over 4 million email and productivity users worldwide every day. Now we’re ready to help you get the most out of your investment.</p>
-        </div>
+        <div class="col-md-4 col-sm-6">
+           <div class="value-prop">
+             <div class="col-md-5 col-sm-6 col-xs-5 center-block">
+               <br class="hidden-sm hidden-xs"/>
+               <br class="hidden-sm hidden-xs"/>
+               <i class="rsweb gen-web circle"></i>
+             </div>
+              <h3 class="center">Free Email Migration</h3>
+              <p class="center">Don’t worry about getting started. With experience migrating over 50,000 mailboxes a month, you can trust our team.</p>
+            </div>
+          </div>
       </div>
-      <div class="col-md-4 col-sm-6">
-        <div class="value-prop">
-          <div class="col-md-5 col-sm-6 col-xs-5 center-block">
-            <i class="rsweb mng-24x7 circle"></i>
-          </div>
-          <br class="hidden-sm hidden-xs"/>
-          <br class="hidden-sm hidden-xs"/>
-          <h3 class="center">24x7x365 Fanatical Support</h3>
-          <p class="center">Receive unlimited, award-winning,  U.S.-based support by phone, chat and email with no per-incident charges.</p>
-          </div>
-        </div>
-      <div class="col-md-4 col-sm-6">
-         <div class="value-prop">
-           <div class="col-md-5 col-sm-6 col-xs-5 center-block">
-             <br class="hidden-sm hidden-xs"/>
-             <br class="hidden-sm hidden-xs"/>
-             <i class="rsweb gen-web circle"></i>
-           </div>
-            <h3 class="center">Free Email Migration</h3>
-            <p class="center">Don’t worry about getting started. With experience migrating over 50,000 mailboxes a month, you can trust our team.</p>
-          </div>
-        </div>
     </div>
-  </div>
 
-  <!--Tabs-->
-  <div class="bg-light-gray standard-padding-top container-fluid">
-    <div class="pricing">
-      <div id="business">
-        <table>
-          <tbody class="centered">
-              <tr style="border-top:1px solid #efefef;">
-                <td class="col-md-2 pricing">
-                  <div class="">
-                      <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
-                      <h3 class="center">Plans</h3><br/>
-                  </div>
-                </td>
-                <td colspan="6">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td colspan="3" class="panel-heading business"><h2 class="center white">Business Plans</h2><p class="semi-bold center white">300 User Maximum</p></td>
-                      <td colspan="3" class="panel-heading enterprise"><h2 class="center white">Enterprise Plans</h2><p class="semi-bold center white">Unlimited Users | Advanced Features</p></td>
-                    </tr>
-                    <tr>
-                    <td class="col-md-2">
-                        <h3 class="teal left">Business <br/>Essentials</h3>
+    <!--Tabs-->
+    <div class="bg-light-gray standard-padding-top container-fluid">
+      <div class="pricing">
+        <div id="business">
+          <table>
+            <tbody class="centered">
+                <tr style="border-top:1px solid #efefef;">
+                  <td class="col-md-2 pricing">
+                    <div class="">
+                        <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
+                        <h3 class="center">Plans</h3><br/>
+                    </div>
+                  </td>
+                  <td colspan="6">
+                  <table>
+                    <tbody>
+                      <tr>
+                        <td colspan="3" class="panel-heading business"><h2 class="center white">Business Plans</h2><p class="semi-bold center white">300 User Maximum</p></td>
+                        <td colspan="3" class="panel-heading enterprise"><h2 class="center white">Enterprise Plans</h2><p class="semi-bold center white">Unlimited Users | Advanced Features</p></td>
+                      </tr>
+                      <tr>
+                      <td class="col-md-2">
+                          <h3 class="teal left">Business <br/>Essentials</h3>
+                          <div class="col-md-10">
+                            <hr/>
+                          </div>
+                          <p><strong>Email</strong><br/>
+                          Exchange email, instant messaging, SharePoint and online versions of Office</p>
+
+                      </td>
+                      <td class="col-md-2">
+                          <h3 class="teal left">Business</h3>
+                          <div class="col-md-10">
+                          <hr/>
+                         </div>
+                          <p><strong>Office 2016</strong><br/>
+                              Full desktop, online and mobile versions of Office<br/></p>
+                      </td>
+                      <td class="col-md-2 panel-heading business">
+                           <h3 class="white left">Business <br/>Premium</h3>
+                           <hr/>
+                           <p class="white"><strong>Email + Office 2016</strong><br/>
+                            All the features in our Business Essentials and Business plans</p>
+                            <div class="triangle"></div>
+                            <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
+                      </td>
+                      <td id="enterprise" class="col-md-2">
+                        <br/>
+                        <h3 class="left">Enterprise<br/>E1</h3>
                         <div class="col-md-10">
                           <hr/>
                         </div>
                         <p><strong>Email</strong><br/>
                         Exchange email, instant messaging, SharePoint and online versions of Office</p>
-
-                    </td>
-                    <td class="col-md-2">
-                        <h3 class="teal left">Business</h3>
+                      </td>
+                      <td id="enterprise" class="col-md-2">
+                        <h3 class="left">Enterprise <br/>ProPlus</h3>
                         <div class="col-md-10">
-                        <hr/>
-                       </div>
+                          <hr/>
+                         </div>
                         <p><strong>Office 2016</strong><br/>
-                            Full desktop, online and mobile versions of Office<br/></p>
-                    </td>
-                    <td class="col-md-2 panel-heading business">
-                         <h3 class="white left">Business <br/>Premium</h3>
+                          Full desktop, online and mobile versions of Office<br/></p>
+                      </td>
+                      <td id="enterprise" class="col-md-2 panel-heading enterprise">
+                         <h3 class="white left">Enterprise E3</h3>
                          <hr/>
                          <p class="white"><strong>Email + Office 2016</strong><br/>
-                          All the features in our Business Essentials and Business plans</p>
-                          <div class="triangle"></div>
-                          <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
-                    </td>
-                    <td id="enterprise" class="col-md-2">
-                      <br/>
-                      <h3 class="left">Enterprise<br/>E1</h3>
-                      <div class="col-md-10">
-                        <hr/>
-                      </div>
-                      <p><strong>Email</strong><br/>
-                      Exchange email, instant messaging, SharePoint and online versions of Office</p>
-                    </td>
-                    <td id="enterprise" class="col-md-2">
-                      <h3 class="left">Enterprise <br/>ProPlus</h3>
-                      <div class="col-md-10">
-                        <hr/>
-                       </div>
-                      <p><strong>Office 2016</strong><br/>
-                        Full desktop, online and mobile versions of Office<br/></p>
-                    </td>
-                    <td id="enterprise" class="col-md-2 panel-heading enterprise">
-                       <h3 class="white left">Enterprise E3</h3>
-                       <hr/>
-                       <p class="white"><strong>Email + Office 2016</strong><br/>
-                        All features from E1 and ProPlus, plus advanced Enterprise tools</p>
-                    </td>
-                    </tr>
-                  </tbody>
-                </table>
-                </td>
-              </tr>
-              <tr>
-                <td class="col-md-2">
-                  <p><br/><br/><strong>Price</strong><br/>
-                  Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong><br/>
-                  To purchase an Enterprise plan, call us or chat with a specialist.</p><br/><br/>
-                </td>
-                <td colspan="6">
-                    <table>
-                      <tbody>
-                        <tr height="130">
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>8</h1>
-                            <p class="center">user/month</p>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>10</h1>
-                              <p class="center">user/month</p>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>15</h1>
-                              <p class="center">user/month</p>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>11</h1>
-                              <p class="center">user/month</p>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>12</h1>
-                              <p class="center">user/month</p>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <h1><sup>$</sup>23</h1>
-                              <p class="center">user/month</p>
-                          </td>
-                        </tr>
-                        <tr height="60" style="border-top:1px solid #efefef;">
-                          <td class="border-right col-md-2">
-                            <div class="col-md-10 center-block">
-                          <br/>
-                          <br/>
-                          <a href="#" class="button lead">Try Now</a>
-                        </div>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <div class="col-md-10 center-block">
-                          <br/>
-                          <br/>
-                          <a href="#" class="button lead">Try Now</a>
-                        </div>
-                          </td>
-                          <td class="border-right col-md-2">
-                            <div class="col-md-10 center-block">
-                          <br/>
-                          <br/>
-                          <a href="#" class="button lead">Try Now</a>
-                        </div>
-                          </td>
-                          <td colspan="3">
-                            <h5 class="center">Call 1-855-715-7307</h5>
-                            <div class="col-md-10 center-block">
-                              <a href="#" class="button lead">Chat</a>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr class="title" height="100">
-                          <td colspan="7">
-                            <h5 class="center">No Long-Term Contract Required</h5>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
+                          All features from E1 and ProPlus, plus advanced Enterprise tools</p>
+                      </td>
+                      </tr>
+                    </tbody>
+                  </table>
                   </td>
-              </tr>
-              <tr>
-                <td class="col-md-2"><p class="semi-bold">Maximum Users per Plan</p></td>
-                <td class="col-md-2"><p class="semi-bold center">300</p></td>
-                <td class="col-md-2"><p class="semi-bold center">300</p></td>
-                <td class="col-md-2"><p class="semi-bold center">300</p></td>
-                <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
-                <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
-                <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
-              </tr>
-              <tr>
-                <td class="col-md-2"><p class="semi-bold">What’s<br/> Included<br/><br/></p></td>
+                </tr>
+                <tr>
+                  <td class="col-md-2">
+                    <p><br/><br/><strong>Price</strong><br/>
+                    Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong><br/>
+                    To purchase an Enterprise plan, call us or chat with a specialist.</p><br/><br/>
+                  </td>
+                  <td colspan="6">
+                      <table>
+                        <tbody>
+                          <tr height="130">
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>8</h1>
+                              <p class="center">user/month</p>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>10</h1>
+                                <p class="center">user/month</p>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>15</h1>
+                                <p class="center">user/month</p>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>11</h1>
+                                <p class="center">user/month</p>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>12</h1>
+                                <p class="center">user/month</p>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <h1><sup>$</sup>23</h1>
+                                <p class="center">user/month</p>
+                            </td>
+                          </tr>
+                          <tr height="60" style="border-top:1px solid #efefef;">
+                            <td class="border-right col-md-2">
+                              <div class="col-md-10 center-block">
+                            <br/>
+                            <br/>
+                            <a href="#" class="button lead">Try Now</a>
+                          </div>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <div class="col-md-10 center-block">
+                            <br/>
+                            <br/>
+                            <a href="#" class="button lead">Try Now</a>
+                          </div>
+                            </td>
+                            <td class="border-right col-md-2">
+                              <div class="col-md-10 center-block">
+                            <br/>
+                            <br/>
+                            <a href="#" class="button lead">Try Now</a>
+                          </div>
+                            </td>
+                            <td colspan="3">
+                              <h5 class="center">Call 1-855-715-7307</h5>
+                              <div class="col-md-10 center-block">
+                                <a href="#" class="button lead">Chat</a>
+                              </div>
+                            </td>
+                          </tr>
+                          <tr class="title" height="100">
+                            <td colspan="7">
+                              <h5 class="center">No Long-Term Contract Required</h5>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </td>
+                </tr>
+                <tr>
+                  <td class="col-md-2"><p class="semi-bold">Maximum Users per Plan</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">300</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">300</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">300</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
+                  <td class="col-md-2"><p class="semi-bold center">Unlimited</p></td>
+                </tr>
+                <tr>
+                  <td class="col-md-2"><p class="semi-bold">What’s<br/> Included<br/><br/></p></td>
+                    <td class="col-md-2">
+                      <ul class="product-icons">
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                  </ul>
+                  </td>
                   <td class="col-md-2">
                     <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                </ul>
-                </td>
-                <td class="col-md-2">
-                  <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                </ul>
-                </td>
-                <td class="col-md-2">
-                  <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                </ul>
-                </td>
-                <td class="col-md-2">
-                  <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                </ul>
-                </td>
-                <td class="col-md-2">
-                  <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                </ul>
-                </td>
-                <td class="col-md-2">
-                  <ul class="product-icons">
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                  <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                </ul>
-                </td>
-              </tr>
-              <tr height="100" class="title half-padding">
-                <td colspan="7"><h4 class="center">Fanatical Support by Rackspace</h4></td>
-              </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p class="semi-bold">Unlimited 24x7x365 U.S.-based support</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p class="semi-bold">Free email migrations to Office 365</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p class="semi-bold">Access to top tier Office 365 experts</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Rapid Managed Escalation</strong><br/>
-                    We work directly with Microsoft to resolve your problems quickly</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr height="100" class="title">
-                      <td colspan="7"><h4 class="center">Office365 Features</h4></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Fully installed Office applications</strong><br/>
-                    Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Onedrive<sup>&reg;</sup></strong><br/>
-                    1TB file storage per user</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Office 2016 on tablets and phones </strong><br/>
-                    For the full Office experience on mobile devices</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Exchange</strong><br/>
-                    Business class email, contacts, calendar and 50GB mailboxes</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>SharePoint and Skype for Business</strong><br/>
-                    Team sites, online meetings, chat, voice and video calls</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Online versions of Office 2016</strong><br/>
-                    Including Word, Excel and PowerPoint</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr height="100" class="title">
-                      <td colspan="7"><h4 class="center">Advanced Features/Benefits</h4></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Yammer</strong><br/>
-                    Corporate social network to help employees collaborate across departments and locations</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Delve</strong><br/>
-                          Personalized search and discovery across Office 365 </p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Active Directory Integration</strong></p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Compliance</strong><br/>
-                    Native Archiving, eDiscovery and mailbox holds</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Azure Rights Management</strong><br/>
-                    Message encryption, Information Rights Management, Data Loss Prevention</p>
-                      </td>
-                      <td class="col-md-2"><p class="gray-light center">Optional</p></td>
-                      <td class="col-md-2"><p class="gray-light center">Optional</p></td>
-                      <td class="col-md-2"><p class="gray-light center">Optional</p></td>
-                      <td class="col-md-2" id="enterprise"><p class="gray-light center">Optional</p></td>
-                      <td class="col-md-2" id="enterprise"><p class="gray-light center">Optional</p></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Enterprise Management </strong><br/>
-                    Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Advanced Skype for Business</strong><br/>
-                    Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                      <td class="col-md-2">
-                        <p><strong>Intranet site for your teams </strong><br/>
-                    With customizable security settings</p>
-                      </td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
-                      <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
-                    </tr>
-              <tr>
-                <td class="col-md-2">
-                  <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
-                </td>
-                <td class="col-md-2">
-                    <div class="col-md-10 center-block">
-                      <br/>
-                      <a href="#" class="button lead">Try Now</a>
-                    </div>
-                </td>
-                <td class="col-md-2">
-                    <div class="col-md-10 center-block">
-                      <br/>
-                      <a href="#" class="button lead">Try Now</a>
-                    </div>
-                </td>
-                <td class="col-md-2">
-                    <div class="col-md-10 center-block">
-                      <br/>
-                      <a href="#" class="button lead">Try Now</a>
-                    </div>
-                </td>
-                <td colspan="3" class="col-md-6 centered">
-                    <h5 class="center">Call 1-855-715-7307</h5>
-                    <a href="#" class="button lead center-block">Chat</a>
-                </td>
-              </tr>
-                </tbody>
-        </table>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                  </ul>
+                  </td>
+                  <td class="col-md-2">
+                    <ul class="product-icons">
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                  </ul>
+                  </td>
+                  <td class="col-md-2">
+                    <ul class="product-icons">
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                  </ul>
+                  </td>
+                  <td class="col-md-2">
+                    <ul class="product-icons">
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                  </ul>
+                  </td>
+                  <td class="col-md-2">
+                    <ul class="product-icons">
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                    <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                  </ul>
+                  </td>
+                </tr>
+                <tr height="100" class="title half-padding">
+                  <td colspan="7"><h4 class="center">Fanatical Support by Rackspace</h4></td>
+                </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p class="semi-bold">Unlimited 24x7x365 U.S.-based support</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p class="semi-bold">Free email migrations to Office 365</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p class="semi-bold">Access to top tier Office 365 experts</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Rapid Managed Escalation</strong><br/>
+                      We work directly with Microsoft to resolve your problems quickly</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr height="100" class="title">
+                        <td colspan="7"><h4 class="center">Office365 Features</h4></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Fully installed Office applications</strong><br/>
+                      Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Onedrive<sup>&reg;</sup></strong><br/>
+                      1TB file storage per user</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Office 2016 on tablets and phones </strong><br/>
+                      For the full Office experience on mobile devices</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Exchange</strong><br/>
+                      Business class email, contacts, calendar and 50GB mailboxes</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>SharePoint and Skype for Business</strong><br/>
+                      Team sites, online meetings, chat, voice and video calls</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Online versions of Office 2016</strong><br/>
+                      Including Word, Excel and PowerPoint</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr height="100" class="title">
+                        <td colspan="7"><h4 class="center">Advanced Features/Benefits</h4></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Yammer</strong><br/>
+                      Corporate social network to help employees collaborate across departments and locations</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Delve</strong><br/>
+                            Personalized search and discovery across Office 365 </p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Active Directory Integration</strong></p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Compliance</strong><br/>
+                      Native Archiving, eDiscovery and mailbox holds</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Azure Rights Management</strong><br/>
+                      Message encryption, Information Rights Management, Data Loss Prevention</p>
+                        </td>
+                        <td class="col-md-2"><p class="gray-light center">Optional</p></td>
+                        <td class="col-md-2"><p class="gray-light center">Optional</p></td>
+                        <td class="col-md-2"><p class="gray-light center">Optional</p></td>
+                        <td class="col-md-2" id="enterprise"><p class="gray-light center">Optional</p></td>
+                        <td class="col-md-2" id="enterprise"><p class="gray-light center">Optional</p></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Enterprise Management </strong><br/>
+                      Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Advanced Skype for Business</strong><br/>
+                      Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                        <td class="col-md-2">
+                          <p><strong>Intranet site for your teams </strong><br/>
+                      With customizable security settings</p>
+                        </td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-times times"></i></td>
+                        <td class="col-md-2" id="enterprise"><i class="fa fa-check check"></i></td>
+                      </tr>
+                <tr>
+                  <td class="col-md-2">
+                    <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
+                  </td>
+                  <td class="col-md-2">
+                      <div class="col-md-10 center-block">
+                        <br/>
+                        <a href="#" class="button lead">Try Now</a>
+                      </div>
+                  </td>
+                  <td class="col-md-2">
+                      <div class="col-md-10 center-block">
+                        <br/>
+                        <a href="#" class="button lead">Try Now</a>
+                      </div>
+                  </td>
+                  <td class="col-md-2">
+                      <div class="col-md-10 center-block">
+                        <br/>
+                        <a href="#" class="button lead">Try Now</a>
+                      </div>
+                  </td>
+                  <td colspan="3" class="col-md-6 centered">
+                      <h5 class="center">Call 1-855-715-7307</h5>
+                      <a href="#" class="button lead center-block">Chat</a>
+                  </td>
+                </tr>
+                  </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-8 center-block half-padding">
+          <h4 class="center">The best part about all of our plans?<br/>
+            They come with our 24x7x365 Fanatical Support.</h4>
+          <a href="#" class="button learning center-block">Explore Fanatical Support</a>
+        </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col-md-8 center-block half-padding">
-        <h4 class="center">The best part about all of our plans?<br/>
-          They come with our 24x7x365 Fanatical Support.</h4>
-        <a href="#" class="button learning center-block">Explore Fanatical Support</a>
+
+    <div class="bg-light-gray standard-padding">
+      <div class="row">
+        <ul id="myTab" class="nav nav-tabs">
+          <li class="active business"><a href="#business" data-toggle="tab">
+            <h2>Business Plans</h2>
+            <p class="semi-bold uppercase">300 User Maximum</p>
+            <p class="hidden-md hidden-lg">Business plans are best for small and medium-sized companies with fewer than 300 users. Combine plans to meet your needs.</p>
+            <img class="hidden-md hidden-lg center-block" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365Logo.png">
+          </a></li>
+          <li class="enterprise"><a href="#enterprise" data-toggle="tab">
+            <h2>Enterprise Plans</h2>
+            <p class="semi-bold uppercase">Unlimited Users | Advanced Features</p>
+            <p class="hidden-md hidden-lg">Enterprise plans are best for companies that require no limit on users and have advanced security, compliance and business analytics needs. Combine plans to create a solution that fits you best.</p>
+            <img class="hidden-md hidden-lg center-block" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365Logo.png">
+          </a></li>
+        </ul>
       </div>
-    </div>
-  </div>
-
-  <div class="bg-light-gray standard-padding">
-    <div class="row">
-      <ul id="myTab" class="nav nav-tabs">
-        <li class="active business"><a href="#business" data-toggle="tab">
-          <h2>Business Plans</h2>
-          <p class="semi-bold uppercase">300 User Maximum</p>
-          <p class="hidden-md hidden-lg">Business plans are best for small and medium-sized companies with fewer than 300 users. Combine plans to meet your needs.</p>
-          <img class="hidden-md hidden-lg center-block" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365Logo.png">
-        </a></li>
-        <li class="enterprise"><a href="#enterprise" data-toggle="tab">
-          <h2>Enterprise Plans</h2>
-          <p class="semi-bold uppercase">Unlimited Users | Advanced Features</p>
-          <p class="hidden-md hidden-lg">Enterprise plans are best for companies that require no limit on users and have advanced security, compliance and business analytics needs. Combine plans to create a solution that fits you best.</p>
-          <img class="hidden-md hidden-lg center-block" src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365Logo.png">
-        </a></li>
-      </ul>
-    </div>
-    <div id="myTabContent" class="tab-content pricing">
-      <div class="tab-pane fade in active" id="business">
-        <div class="container border half-padding-top">
-            <div class="row half-padding-top">
-                <div class="col-md-12">
-                    <p class="center">Enterprise plans are best for companies that require <strong>no limit on users</strong> and have advanced security</strong>, <strong>compliance</strong> and <strong>business analytics</strong> needs. Combine plans to create a solution that fits you best.</p>
-                    <p class="center"><a href="[rs_link:office-365:pick-your-plan:compare]">Compare All Plans</a></p>
-                </div>
-            </div>
-            <div class="row pricing-header-row">
-            <div class="col-md-3 pricing hidden-sm hidden-xs">
-                <div class="panel panel-pricing">
-                    <div class="panel-heading standard-padding">
-                        <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
-                        <h3 class="left">Plans</h3><br/>
-                    </div>
-                    <div class="panel-body pricing hidden-md hidden-lg">
-                      <p><strong>Price</strong><br/>
-                        Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3 pricing">
-              <div class="panel panel-pricing">
-                <div class="panel-heading">
-                    <h3 class="teal left">Business <br/>Essentials</h3>
-                    <hr class="white"/>
-                    <p><strong>Email</strong><br/>
-                    Exchange email, instant messaging, SharePoint and online versions of Office</p>
-
-                </div>
-                <div class="panel-body pricing hidden-md hidden-lg">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <p><strong>What's<br/> Included</strong><br/>
-                        Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
-                    </div>
+      <div id="myTabContent" class="tab-content pricing">
+        <div class="tab-pane fade in active" id="business">
+          <div class="container border half-padding-top">
+              <div class="row half-padding-top">
+                  <div class="col-md-12">
+                      <p class="center">Enterprise plans are best for companies that require <strong>no limit on users</strong> and have advanced security</strong>, <strong>compliance</strong> and <strong>business analytics</strong> needs. Combine plans to create a solution that fits you best.</p>
+                      <p class="center"><a href="[rs_link:office-365:pick-your-plan:compare]">Compare All Plans</a></p>
                   </div>
-                  <div class="row">
-                    <div class="col-xs-6">
-                      <p class="left"><strong>Maximum Users per Plan</strong></p>
-                    </div>
-                    <div class="col-xs-6">
-                      <p class="right semi-bold center">300</p>
-                    </div>
-                  </div>
-                <a href="#support-mobile-1" data-toggle="collapse"><div class="row title">
-                    <div class="col-md-12">
-                      <h3 class="center left">Fanatical Support from Rackspace</h3>
-                    </div>
-                  </div>
-                </a>
-                <div id="support-mobile-1" class="collapse in">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Rapid Managed Escalation</strong><br/>
-                              We work directly with Microsoft to resolve your problems quickly</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-                <a href="#features-mobile-1" data-toggle="collapse">
-                  <div class="row title">
-                    <div class="col-md-12">
-                      <h3 class="center">Microsoft Office 365 Features</h3>
-                    </div>
-                  </div>
-                </a>
-                <div id="features-mobile-1" class="collapse">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p><strong>Fully installed Office applications</strong><br/>
-                              Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
-                              1TB file storage per user</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Office 2016 on tablets and phones</strong><br/>
-                              For the full Office experience on mobile devices</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Exchange</strong><br/>
-                              Business-class email, contacts, calendar and 50GB mailboxes</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>SharePoint and Skype for Business</strong><br/>
-                              Team sites, online meetings, chat, voice and video calls</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Online versions of Office 2016</strong><br/>
-                              Including Word, Excel and PowerPoint</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-                <a href="#advanced-mobile-1" data-toggle="collapse">
-                  <div class="row title">
-                    <div class="col-md-12">
-                      <h3 class="center">Advanced Features/Benefits</h3>
-                    </div>
-                  </div>
-                </a>
-                <div id="advanced-mobile-1" class="collapse">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p><strong>Yammer</strong><br/>
-                              Corporate social network to help employees collaborate across departments and locations</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Delve</strong><br/>
-                              Personalized search and discovery across Office 365 </p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Active Directory Integration</strong></p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Compliance</strong><br/>
-                              Native archiving, eDiscovery and mailbox holds</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Azure Rights Management</strong><br/>
-                              Message encryption, Information Rights Management, Data Loss Prevention</p></td>
-                            <td>Optional</td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Enterprise Management</strong><br/>
-                              Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Advanced Skype for Business</strong><br/>
-                              Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Intranet site for your teams</strong><br/>
-                              With customizable security settings</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                            <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                  <div class="row half-padding">
-                    <div class="col-md-12">
-                      <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
-                    </div>
-                    <div class="col-md-12">
-                      <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
-                    </div>
-                  </div>
-                </div>
-                </div>
               </div>
-            </div>
-            <div class="col-md-3 pricing">
+              <div class="row pricing-header-row">
+              <div class="col-md-3 pricing hidden-sm hidden-xs">
+                  <div class="panel panel-pricing">
+                      <div class="panel-heading standard-padding">
+                          <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
+                          <h3 class="left">Plans</h3><br/>
+                      </div>
+                      <div class="panel-body pricing hidden-md hidden-lg">
+                        <p><strong>Price</strong><br/>
+                          Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                      </div>
+                  </div>
+              </div>
+              <div class="col-md-3 pricing">
                 <div class="panel panel-pricing">
-                    <div class="panel-heading">
-                      <h3 class="teal left"><br/>Business</h3>
+                  <div class="panel-heading">
+                      <h3 class="teal left">Business <br/>Essentials</h3>
                       <hr class="white"/>
-                      <p><strong>Office 2016</strong><br/>
-                        Full desktop, online and mobile versions of Office<br/></p>
-                    </div>
-                    <div class="panel-body pricing hidden-md hidden-lg">
-                  <div class="row">
+                      <p><strong>Email</strong><br/>
+                      Exchange email, instant messaging, SharePoint and online versions of Office</p>
+
+                  </div>
+                  <div class="panel-body pricing hidden-md hidden-lg">
+                    <div class="row">
                       <div class="col-md-12">
                         <p><strong>What's<br/> Included</strong><br/>
                           Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
@@ -792,26 +617,25 @@
                         <p class="right semi-bold center">300</p>
                       </div>
                     </div>
-                    <a href="#support-mobile-2" data-toggle="collapse" class="center">
-                    <div class="row title">
+                  <a href="#support-mobile-1" data-toggle="collapse"><div class="row title">
                       <div class="col-md-12">
-                        <h3>Fanatical Support from Rackspace</h3>
-                        </div>
+                        <h3 class="center left">Fanatical Support from Rackspace</h3>
                       </div>
-                    </a>
-                    <div id="support-mobile-2" class="collapse in">
-                      <div class="row">
-                        <div class="col-md-12">
+                    </div>
+                  </a>
+                  <div id="support-mobile-1" class="collapse in">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
                               <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
+    U.S.-based support</p></td>
                               <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                              <td><i class="fa fa-times times"></i></td>
+                              <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
@@ -827,22 +651,22 @@
                       </div>
                     </div>
                   </div>
-                    <a href="#features-mobile-2" data-toggle="collapse" class="center">
+                  <a href="#features-mobile-1" data-toggle="collapse">
                     <div class="row title">
                       <div class="col-md-12">
-                        <h3>Microsoft Office 365 Features</h3>
+                        <h3 class="center">Microsoft Office 365 Features</h3>
                       </div>
                     </div>
                   </a>
-                    <div id="features-mobile-2" class="collapse">
-                      <div class="row">
-                        <div class="col-md-12">
+                  <div id="features-mobile-1" class="collapse">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
                               <td><p><strong>Fully installed Office applications</strong><br/>
                                 Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
-                              <td><i class="fa fa-check check"></i></td>
+                              <td><i class="fa fa-times times"></i></td>
                             </tr>
                             <tr>
                               <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
@@ -852,17 +676,17 @@
                             <tr>
                               <td><p><strong>Office 2016 on tablets and phones</strong><br/>
                                 For the full Office experience on mobile devices</p></td>
-                              <td><i class="fa fa-check check"></i></td>
+                              <td><i class="fa fa-times times"></i></td>
                             </tr>
                             <tr>
                               <td><p><strong>Exchange</strong><br/>
                                 Business-class email, contacts, calendar and 50GB mailboxes</p></td>
-                              <td><i class="fa fa-times times"></i></td>
+                              <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p><strong>SharePoint and Skype for Business</strong><br/>
                                 Team sites, online meetings, chat, voice and video calls</p></td>
-                              <td><i class="fa fa-times times"></i></td>
+                              <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p><strong>Online versions of Office 2016</strong><br/>
@@ -874,22 +698,22 @@
                       </div>
                     </div>
                   </div>
-                    <a href="#advanced-mobile-2" data-toggle="collapse" class="center">
+                  <a href="#advanced-mobile-1" data-toggle="collapse">
                     <div class="row title">
                       <div class="col-md-12">
-                        <h3>Advanced Features/Benefits</h3>
+                        <h3 class="center">Advanced Features/Benefits</h3>
                       </div>
                     </div>
                   </a>
-                    <div id="advanced-mobile-2" class="collapse">
-                      <div class="row">
-                        <div class="col-md-12">
+                  <div id="advanced-mobile-1" class="collapse">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
                               <td><p><strong>Yammer</strong><br/>
                                 Corporate social network to help employees collaborate across departments and locations</p></td>
-                              <td><i class="fa fa-times times"></i></td>
+                              <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p><strong>Delve</strong><br/>
@@ -927,13 +751,12 @@
                             </tr>
                             <tr>
                               <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a></td>
+                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a></td>
                             </tr>
                           </tbody>
                         </table>
                       </div>
                     </div>
-                  </div>
                     <div class="row half-padding">
                       <div class="col-md-12">
                         <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
@@ -943,1085 +766,909 @@
                       </div>
                     </div>
                   </div>
+                  </div>
                 </div>
-            </div>
-            <div class="col-md-3 pricing">
-            <div class="panel panel-pricing">
-              <div class="panel-heading business">
-                 <h3 class="white left">Business <br/>Premium</h3>
-                 <hr class="white"/>
-                 <p class="white"><strong>Email + Office 2016</strong><br/>
-                  All the features in our Business Essentials and Business plans</p>
-                  <div class="triangle"></div>
-                  <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
               </div>
-              <div class="panel-body pricing hidden-md hidden-lg">
-                <div class="row">
-                      <div class="col-md-12">
-                        <p><strong>What's<br/> Included</strong><br/>
-                          Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+              <div class="col-md-3 pricing">
+                  <div class="panel panel-pricing">
+                      <div class="panel-heading">
+                        <h3 class="teal left"><br/>Business</h3>
+                        <hr class="white"/>
+                        <p><strong>Office 2016</strong><br/>
+                          Full desktop, online and mobile versions of Office<br/></p>
                       </div>
-                    </div>
-                <div class="row">
-                      <div class="col-xs-6">
-                        <p class="left"><strong>Maximum Users per Plan</strong></p>
-                      </div>
-                      <div class="col-xs-6">
-                        <p class="right semi-bold center">300</p>
-                      </div>
-                    </div>
-                <a href="#support-mobile-3" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Fanatical Support from Rackspace</h3>
-                      </div>
-                    </div>
-                  </a>
-                <div id="support-mobile-3" class="collapse in">
-                      <div class="row">
+                      <div class="panel-body pricing hidden-md hidden-lg">
+                    <div class="row">
                         <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Rapid Managed Escalation</strong><br/>
-                                We work directly with Microsoft to resolve your problems quickly</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                          </tbody>
-                        </table>
+                          <p><strong>What's<br/> Included</strong><br/>
+                            Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                <a href="#features-mobile-3" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Microsoft Office 365 Features</h3>
-                      </div>
-                    </div>
-                  </a>
-                <div id="features-mobile-3" class="collapse">
                       <div class="row">
-                        <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p><strong>Fully installed Office applications</strong><br/>
-                                Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
-                                1TB file storage per user</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Office 2016 on tablets and phones</strong><br/>
-                                For the full Office experience on mobile devices</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Exchange</strong><br/>
-                                Business-class email, contacts, calendar and 50GB mailboxes</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>SharePoint and Skype for Business</strong><br/>
-                                Team sites, online meetings, chat, voice and video calls</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Online versions of Office 2016</strong><br/>
-                                Including Word, Excel and PowerPoint</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                          </tbody>
-                        </table>
+                        <div class="col-xs-6">
+                          <p class="left"><strong>Maximum Users per Plan</strong></p>
+                        </div>
+                        <div class="col-xs-6">
+                          <p class="right semi-bold center">300</p>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                <a href="#advanced-mobile-3" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Advanced Features/Benefits</h3>
+                      <a href="#support-mobile-2" data-toggle="collapse" class="center">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3>Fanatical Support from Rackspace</h3>
                           </div>
+                        </div>
+                      </a>
+                      <div id="support-mobile-2" class="collapse in">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p class="semi-bold">Unlimited 24x7x365
+    U.S.-based support</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Free email migrations to Office 365</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Rapid Managed Escalation</strong><br/>
+                                  We work directly with Microsoft to resolve your problems quickly</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#features-mobile-2" data-toggle="collapse" class="center">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3>Microsoft Office 365 Features</h3>
+                        </div>
                       </div>
                     </a>
-                <div id="advanced-mobile-3" class="collapse">
-                      <div class="row">
+                      <div id="features-mobile-2" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Fully installed Office applications</strong><br/>
+                                  Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
+                                  1TB file storage per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Office 2016 on tablets and phones</strong><br/>
+                                  For the full Office experience on mobile devices</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Exchange</strong><br/>
+                                  Business-class email, contacts, calendar and 50GB mailboxes</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>SharePoint and Skype for Business</strong><br/>
+                                  Team sites, online meetings, chat, voice and video calls</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Online versions of Office 2016</strong><br/>
+                                  Including Word, Excel and PowerPoint</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#advanced-mobile-2" data-toggle="collapse" class="center">
+                      <div class="row title">
                         <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p><strong>Yammer</strong><br/>
-                                Corporate social network to help employees collaborate across departments and locations</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Delve</strong><br/>
-                                Personalized search and discovery across Office 365 </p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Active Directory Integration</strong></p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Compliance</strong><br/>
-                                Native archiving, eDiscovery and mailbox holds</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Azure Rights Management</strong><br/>
-                                Message encryption, Information Rights Management, Data Loss Prevention</p></td>
-                              <td>Optional</td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Enterprise Management</strong><br/>
-                                Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Advanced Skype for Business</strong><br/>
-                                Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Intranet site for your teams</strong><br/>
-                                With customizable security settings</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a></td>
-                            </tr>
-                          </tbody>
-                        </table>
+                          <h3>Advanced Features/Benefits</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="advanced-mobile-2" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Yammer</strong><br/>
+                                  Corporate social network to help employees collaborate across departments and locations</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Delve</strong><br/>
+                                  Personalized search and discovery across Office 365 </p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Active Directory Integration</strong></p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Compliance</strong><br/>
+                                  Native archiving, eDiscovery and mailbox holds</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Azure Rights Management</strong><br/>
+                                  Message encryption, Information Rights Management, Data Loss Prevention</p></td>
+                                <td>Optional</td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Enterprise Management</strong><br/>
+                                  Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Advanced Skype for Business</strong><br/>
+                                  Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Intranet site for your teams</strong><br/>
+                                  With customizable security settings</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
+                                <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <div class="row half-padding">
+                        <div class="col-md-12">
+                          <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
+                        </div>
+                        <div class="col-md-12">
+                          <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+                        </div>
                       </div>
                     </div>
                   </div>
-                <div class="row half-padding">
-                  <div class="col-md-12">
-                    <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
-                  </div>
-                  <div class="col-md-12">
-                    <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
-                  </div>
-                    </div>
-                  </div>
-                </div>
               </div>
-          </div>
-            <div class="hidden-xs hidden-sm">
-            <div class="row price-compare">
-              <div class="col-md-3">
-                <p><br/><br/><strong>Price</strong><br/>
-                    Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong></p><br/><br/>
-              </div>
-              <div class="col-md-9">
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>8</h1>
-                    <p class="center">user/month</p>
-                    <div class="col-md-8 center-block">
-                      <a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a>
-                    </div>
-                  </div>
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>10</h1>
-                    <p class="center">user/month</p>
-                    <div class="col-md-8 center-block">
-                      <a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a>
-                    </div>
-                  </div>
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>15</h1>
-                    <p class="center">user/month</p>
-                    <div class="col-md-8 center-block">
-                      <a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a>
-                    </div>
-                  </div>
-                  <div class="col-md-12 title">
-                    <h5 class="center">No Long-Term Contract Required</h5>
-                  </div>
-                </div>
-              </div>
-            <div class="row border">
-              <div class="col-md-3">
-                <p class="semi-bold">Maximum Users per Plan</p>
-              </div>
-              <div class="col-md-9">
-                <div class="row">
-                  <div class="col-md-4">
-                    <p class="semi-bold center">300</p>
-                  </div>
-                  <div class="col-md-4">
-                    <p class="semi-bold center">300</p>
-                  </div>
-                  <div class="col-md-4">
-                    <p class="semi-bold center">300</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-md-3">
-                <p class="semi-bold">What’s<br/> Included<br/><br/></p>
-              </div>
-              <div class="col-md-9">
-                <div class="row">
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                    </ul>
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                    </ul>
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#support1" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                  <h4 class="center">Fanatical Support from Rackspace</h4>
-                </div>
-              </div>
-            </a>
-            <div id="support1" class="collapse in">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Unlimited 24x7x365<br />U.S.-based support</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Free email migrations to Office 365</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Access to top tier Office 365 experts</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Rapid Managed Escalation</strong><br/>
-                        We work directly with Microsoft to resolve your problems quickly</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#features1" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                   <h4 class="center">Microsoft Office 365 Features</h4>
-                </div>
-              </div>
-            </a>
-            <div id="features1" class="collapse">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Fully installed Office applications</strong><br/>
-                        Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>OneDrive<sup>&reg;</sup></strong><br/>
-                        1TB file storage per user</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Office 2016 on tablets and phones </strong><br/>
-                        For the full Office experience on mobile devices</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Exchange</strong><br/>
-                        Business-class email, contacts, calendar and 50GB mailboxes</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>SharePoint and Skype for Busines</strong><br/>
-                        Team sites, online meetings, chat, voice and video calls</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Online versions of Office 2016</strong><br/>
-                        Including Word, Excel and PowerPoint</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#advanced1" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                  <h4 class="center">Advanced Features/Benefits</h4>
-                </div>
-              </div>
-            </a>
-            <div id="advanced1" class="collapse">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Yammer</strong><br/>
-                        Corporate social network to help employees collaborate across departments and locations</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Delve</strong><br/>
-                        Personalized search and discovery across Office 365 </p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Active Directory Integration</strong></p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Compliance</strong><br/>
-                        Native Archiving, eDiscovery and mailbox holds</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Azure Rights Management</strong><br/>
-                        Message encryption, Information Rights Management, Data Loss Prevention</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Enterprise Management </strong><br/>
-                        Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Advanced Skype for Business</strong><br/>
-                        Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Intranet site for your teams </strong><br/>
-                        With customizable security settings</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row border centered row-eq-height">
-                <div class="col-md-3">
-                  <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
-                </div>
-                <div class="col-md-9">
-                  <div class="row">
-                    <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
-                    </div>
-                    <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
-                    </div>
-                    <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
-                    </div>
-                  </div>
-                </div>
-            </div>
-            <div class="row">
-              <div class="col-md-8 center-block half-padding">
-                <h4 class="center">The best part about all of our plans?<br/>
-                  They come with our 24x7x365 Fanatical Support.</h4>
-                <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="tab-pane fade" id="enterprise">
-        <div class="container">
-          <div class="row pricing-header-row">
-            <div class="col-md-3 pricing hidden-sm hidden-xs">
-                <div class="panel panel-pricing">
-                    <div class="panel-heading standard-padding">
-                        <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
-                        <h3 class="left">Plans</h3><br/>
-                    </div>
-                    <div class="panel-body pricing hidden-md hidden-lg">
-                      <p><strong>Price</strong><br/>
-                        Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3 pricing">
+              <div class="col-md-3 pricing">
               <div class="panel panel-pricing">
-                <div class="panel-heading">
-                  <br/>
-                    <h3 class="left">Enterprise E1</h3>
-                    <hr class="white"/>
-                    <p><strong>Email</strong><br/>
-                    Exchange email, instant messaging, SharePoint and online versions of Office</p>
-
+                <div class="panel-heading business">
+                   <h3 class="white left">Business <br/>Premium</h3>
+                   <hr class="white"/>
+                   <p class="white"><strong>Email + Office 2016</strong><br/>
+                    All the features in our Business Essentials and Business plans</p>
+                    <div class="triangle"></div>
+                    <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
                 </div>
                 <div class="panel-body pricing hidden-md hidden-lg">
                   <div class="row">
-                    <div class="col-md-12">
-                      <p><strong>What's<br/> Included</strong><br/>
-                        Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-xs-6">
-                      <p class="left"><strong>Maximum Users per Plan</strong></p>
-                    </div>
-                    <div class="col-xs-6">
-                      <p class="right semi-bold center">Unlimited</p>
-                    </div>
-                  </div>
-                  <a href="#support-mobile-enterprise-1" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Fanatical Support from Rackspace</h3>
+                        <div class="col-md-12">
+                          <p><strong>What's<br/> Included</strong><br/>
+                            Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                        </div>
                       </div>
-                    </div>
-                  </a>
-                  <div id="support-mobile-enterprise-1" class="collapse in">
                   <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Rapid Managed Escalation</strong><br/>
-                              We work directly with Microsoft to resolve your problems quickly</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-                  <a href="#features-mobile-enterprise-1" data-toggle="collapse">
-                  <div class="row title">
-                    <div class="col-md-12">
-                      <h3 class="center">Microsoft Office 365 Features</h3>
-                    </div>
-                  </div>
-                </a>
-                  <div id="features-mobile-enterprise-1" class="collapse">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p><strong>Fully installed Office applications</strong><br/>
-                              Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
-                              1TB file storage per user</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Office 2016 on tablets and phones</strong><br/>
-                              For the full Office experience on mobile devices</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Exchange</strong><br/>
-                              Business-class email, contacts, calendar and 50GB mailboxes</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>SharePoint and Skype for Business</strong><br/>
-                              Team sites, online meetings, chat, voice and video calls</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Online versions of Office 2016</strong><br/>
-                              Including Word, Excel and PowerPoint</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-                  <a href="#advanced-mobile-enterprise-1" data-toggle="collapse">
-                  <div class="row title">
-                    <div class="col-md-12">
-                      <h3 class="center">Advanced Features/Benefits</h3>
-                    </div>
-                </div>
-                </a>
-                  <div id="advanced-mobile-enterprise-1" class="collapse">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <table>
-                        <tbody>
-                          <tr>
-                            <td><p><strong>Yammer</strong><br/>
-                              Corporate social network to help employees collaborate across departments and locations</p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Delve</strong><br/>
-                              Personalized search and discovery across Office 365 </p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Active Directory Integration</strong></p></td>
-                            <td><i class="fa fa-check check"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Compliance</strong><br/>
-                              Native archiving, eDiscovery and mailbox holds</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Azure Rights Management</strong><br/>
-                              Message encryption, Information Rights Management, Data Loss Prevention</p></td>
-                            <td>Optional</td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Enterprise Management</strong><br/>
-                              Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Advanced Skype for Business</strong><br/>
-                              Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><p><strong>Intranet site for your teams</strong><br/>
-                              With customizable security settings</p></td>
-                            <td><i class="fa fa-times times"></i></td>
-                          </tr>
-                          <tr>
-                            <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                            <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                  <div class="row half-padding">
-                    <div class="col-md-12">
-                      <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
-                    </div>
-                    <div class="col-md-12">
-                      <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
-                    </div>
-                  </div>
-                </div>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-3 pricing">
-                <div class="panel panel-pricing">
-                    <div class="panel-heading">
-                      <h3 class="left">Enterprise <br/>ProPlus</h3>
-                      <hr class="white" style="margin-top: 5px;"/>
-                      <p><strong>Office 2016</strong><br/>
-                        Full desktop, online and mobile versions of Office<br/></p>
-                    </div>
-                    <div class="panel-body pricing hidden-md hidden-lg">
-                  <div class="row">
-                      <div class="col-md-12">
-                        <p><strong>What's<br/> Included</strong><br/>
-                          Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                        <div class="col-xs-6">
+                          <p class="left"><strong>Maximum Users per Plan</strong></p>
+                        </div>
+                        <div class="col-xs-6">
+                          <p class="right semi-bold center">300</p>
+                        </div>
                       </div>
-                    </div>
-                    <div class="row">
-                      <div class="col-xs-6">
-                        <p class="left"><strong>Maximum Users per Plan</strong></p>
-                      </div>
-                      <div class="col-xs-6">
-                        <p class="right semi-bold center">Unlimited</p>
-                      </div>
-                    </div>
-                    <a href="#support-mobile-enterprise-2" data-toggle="collapse">
+                  <a href="#support-mobile-3" data-toggle="collapse">
                       <div class="row title">
                         <div class="col-md-12">
                           <h3 class="center">Fanatical Support from Rackspace</h3>
                         </div>
                       </div>
                     </a>
-                    <div id="support-mobile-enterprise-2" class="collapse in">
-                      <div class="row">
+                  <div id="support-mobile-3" class="collapse in">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p class="semi-bold">Unlimited 24x7x365
+    U.S.-based support</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Free email migrations to Office 365</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Rapid Managed Escalation</strong><br/>
+                                  We work directly with Microsoft to resolve your problems quickly</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  <a href="#features-mobile-3" data-toggle="collapse">
+                      <div class="row title">
                         <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Rapid Managed Escalation</strong><br/>
-                                We work directly with Microsoft to resolve your problems quickly</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                          </tbody>
-                        </table>
+                          <h3 class="center">Microsoft Office 365 Features</h3>
+                        </div>
+                      </div>
+                    </a>
+                  <div id="features-mobile-3" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Fully installed Office applications</strong><br/>
+                                  Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
+                                  1TB file storage per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Office 2016 on tablets and phones</strong><br/>
+                                  For the full Office experience on mobile devices</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Exchange</strong><br/>
+                                  Business-class email, contacts, calendar and 50GB mailboxes</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>SharePoint and Skype for Business</strong><br/>
+                                  Team sites, online meetings, chat, voice and video calls</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Online versions of Office 2016</strong><br/>
+                                  Including Word, Excel and PowerPoint</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                    <a href="#features-mobile-enterprise-2" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Microsoft Office 365 Features</h3>
-                      </div>
-                    </div>
-                  </a>
-                    <div id="features-mobile-enterprise-2" class="collapse">
-                      <div class="row">
+                  <a href="#advanced-mobile-3" data-toggle="collapse">
+                      <div class="row title">
                         <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p><strong>Fully installed Office applications</strong><br/>
-                                Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
-                                1TB file storage per user</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Office 2016 on tablets and phones</strong><br/>
-                                For the full Office experience on mobile devices</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Exchange</strong><br/>
-                                Business-class email, contacts, calendar and 50GB mailboxes</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>SharePoint and Skype for Business</strong><br/>
-                                Team sites, online meetings, chat, voice and video calls</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Online versions of Office 2016</strong><br/>
-                                Including Word, Excel and PowerPoint</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                          </tbody>
-                        </table>
+                          <h3 class="center">Advanced Features/Benefits</h3>
+                            </div>
+                        </div>
+                      </a>
+                  <div id="advanced-mobile-3" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Yammer</strong><br/>
+                                  Corporate social network to help employees collaborate across departments and locations</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Delve</strong><br/>
+                                  Personalized search and discovery across Office 365 </p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Active Directory Integration</strong></p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Compliance</strong><br/>
+                                  Native archiving, eDiscovery and mailbox holds</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Azure Rights Management</strong><br/>
+                                  Message encryption, Information Rights Management, Data Loss Prevention</p></td>
+                                <td>Optional</td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Enterprise Management</strong><br/>
+                                  Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Advanced Skype for Business</strong><br/>
+                                  Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Intranet site for your teams</strong><br/>
+                                  With customizable security settings</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
+                                <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                    <a href="#advanced-mobile-enterprise-2" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Advanced Features/Benefits</h3>
-                      </div>
+                  <div class="row half-padding">
+                    <div class="col-md-12">
+                      <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
                     </div>
-                  </a>
-                    <div id="advanced-mobile-enterprise-2" class="collapse">
-                      <div class="row">
-                        <div class="col-md-12">
-                        <table>
-                          <tbody>
-                            <tr>
-                              <td><p><strong>Yammer</strong><br/>
-                                Corporate social network to help employees collaborate across departments and locations</p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Delve</strong><br/>
-                                Personalized search and discovery across Office 365 </p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Active Directory Integration</strong></p></td>
-                              <td><i class="fa fa-check check"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Compliance</strong><br/>
-                                Native archiving, eDiscovery and mailbox holds</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Azure Rights Management</strong><br/>
-                                Message encryption, Information Rights Management, Data Loss Prevention</p></td>
-                              <td>Optional</td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Enterprise Management</strong><br/>
-                                Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Advanced Skype for Business</strong><br/>
-                                Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><p><strong>Intranet site for your teams</strong><br/>
-                                With customizable security settings</p></td>
-                              <td><i class="fa fa-times times"></i></td>
-                            </tr>
-                            <tr>
-                              <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a></td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
+                    <div class="col-md-12">
+                      <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
                     </div>
-                  </div>
-                    <div class="row half-padding">
-                      <div class="col-md-12">
-                        <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
-                      </div>
-                      <div class="col-md-12">
-                        <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
                       </div>
                     </div>
                   </div>
                 </div>
             </div>
-            <div class="col-md-3 pricing">
-            <div class="panel panel-pricing">
-              <div class="panel-heading enterprise">
-                <br/>
-                 <h3 class="white left">Enterprise E3</h3>
-                 <hr class="white"/>
-                 <p class="white"><strong>Email + Office 2016</strong><br/>
-                  All features from E1 and ProPlus, plus advanced Enterprise tools</p>
+              <div class="hidden-xs hidden-sm">
+              <div class="row price-compare">
+                <div class="col-md-3">
+                  <p><br/><br/><strong>Price</strong><br/>
+                      Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong></p><br/><br/>
+                </div>
+                <div class="col-md-9">
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>8</h1>
+                      <p class="center">user/month</p>
+                      <div class="col-md-8 center-block">
+                        <a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a>
+                      </div>
+                    </div>
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>10</h1>
+                      <p class="center">user/month</p>
+                      <div class="col-md-8 center-block">
+                        <a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a>
+                      </div>
+                    </div>
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>15</h1>
+                      <p class="center">user/month</p>
+                      <div class="col-md-8 center-block">
+                        <a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a>
+                      </div>
+                    </div>
+                    <div class="col-md-12 title">
+                      <h5 class="center">No Long-Term Contract Required</h5>
+                    </div>
+                  </div>
+                </div>
+              <div class="row border">
+                <div class="col-md-3">
+                  <p class="semi-bold">Maximum Users per Plan</p>
+                </div>
+                <div class="col-md-9">
+                  <div class="row">
+                    <div class="col-md-4">
+                      <p class="semi-bold center">300</p>
+                    </div>
+                    <div class="col-md-4">
+                      <p class="semi-bold center">300</p>
+                    </div>
+                    <div class="col-md-4">
+                      <p class="semi-bold center">300</p>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="panel-body pricing hidden-md hidden-lg">
+              <div class="row">
+                <div class="col-md-3">
+                  <p class="semi-bold">What’s<br/> Included<br/><br/></p>
+                </div>
+                <div class="col-md-9">
+                  <div class="row">
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                      </ul>
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                      </ul>
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#support1" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                    <h4 class="center">Fanatical Support from Rackspace</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="support1" class="collapse in">
                 <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Unlimited 24x7x365<br />U.S.-based support</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Free email migrations to Office 365</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Access to top tier Office 365 experts</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Rapid Managed Escalation</strong><br/>
+                          We work directly with Microsoft to resolve your problems quickly</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#features1" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                     <h4 class="center">Microsoft Office 365 Features</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="features1" class="collapse">
+                <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Fully installed Office applications</strong><br/>
+                          Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>OneDrive<sup>&reg;</sup></strong><br/>
+                          1TB file storage per user</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Office 2016 on tablets and phones </strong><br/>
+                          For the full Office experience on mobile devices</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Exchange</strong><br/>
+                          Business-class email, contacts, calendar and 50GB mailboxes</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>SharePoint and Skype for Busines</strong><br/>
+                          Team sites, online meetings, chat, voice and video calls</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Online versions of Office 2016</strong><br/>
+                          Including Word, Excel and PowerPoint</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#advanced1" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                    <h4 class="center">Advanced Features/Benefits</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="advanced1" class="collapse">
+                <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Yammer</strong><br/>
+                          Corporate social network to help employees collaborate across departments and locations</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Delve</strong><br/>
+                          Personalized search and discovery across Office 365 </p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Active Directory Integration</strong></p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Compliance</strong><br/>
+                          Native Archiving, eDiscovery and mailbox holds</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Azure Rights Management</strong><br/>
+                          Message encryption, Information Rights Management, Data Loss Prevention</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Enterprise Management </strong><br/>
+                          Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Advanced Skype for Business</strong><br/>
+                          Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Intranet site for your teams </strong><br/>
+                          With customizable security settings</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row border centered row-eq-height">
+                  <div class="col-md-3">
+                    <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
+                  </div>
+                  <div class="col-md-9">
+                    <div class="row">
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                    </div>
+                  </div>
+              </div>
+              <div class="row">
+                <div class="col-md-8 center-block half-padding">
+                  <h4 class="center">The best part about all of our plans?<br/>
+                    They come with our 24x7x365 Fanatical Support.</h4>
+                  <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tab-pane fade" id="enterprise">
+          <div class="container">
+            <div class="row pricing-header-row">
+              <div class="col-md-3 pricing hidden-sm hidden-xs">
+                  <div class="panel panel-pricing">
+                      <div class="panel-heading standard-padding">
+                          <img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/o365LogoBlackv2.png"/>
+                          <h3 class="left">Plans</h3><br/>
+                      </div>
+                      <div class="panel-body pricing hidden-md hidden-lg">
+                        <p><strong>Price</strong><br/>
+                          Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                      </div>
+                  </div>
+              </div>
+              <div class="col-md-3 pricing">
+                <div class="panel panel-pricing">
+                  <div class="panel-heading">
+                    <br/>
+                      <h3 class="left">Enterprise E1</h3>
+                      <hr class="white"/>
+                      <p><strong>Email</strong><br/>
+                      Exchange email, instant messaging, SharePoint and online versions of Office</p>
+
+                  </div>
+                  <div class="panel-body pricing hidden-md hidden-lg">
+                    <div class="row">
                       <div class="col-md-12">
                         <p><strong>What's<br/> Included</strong><br/>
                           Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
@@ -2035,26 +1682,26 @@
                         <p class="right semi-bold center">Unlimited</p>
                       </div>
                     </div>
-                    <a href="#support-mobile-enterprise-3" data-toggle="collapse">
-                    <div class="row title">
-                      <div class="col-md-12">
-                        <h3 class="center">Fanatical Support from Rackspace</h3>
-                      </div>
-                    </div>
-                  </a>
-                    <div id="support-mobile-enterprise-3" class="collapse in">
-                      <div class="row">
+                    <a href="#support-mobile-enterprise-1" data-toggle="collapse">
+                      <div class="row title">
                         <div class="col-md-12">
+                          <h3 class="center">Fanatical Support from Rackspace</h3>
+                        </div>
+                      </div>
+                    </a>
+                    <div id="support-mobile-enterprise-1" class="collapse in">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
                               <td><p class="semi-bold">Unlimited 24x7x365
-  U.S.-based support</p></td>
+    U.S.-based support</p></td>
                               <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p class="semi-bold">Free email migrations to Office 365</p></td>
-                              <td><i class="fa fa-times times"></i></td>
+                              <td><i class="fa fa-check check"></i></td>
                             </tr>
                             <tr>
                               <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
@@ -2070,16 +1717,16 @@
                       </div>
                     </div>
                   </div>
-                    <a href="#features-mobile-enterprise-3" data-toggle="collapse">
+                    <a href="#features-mobile-enterprise-1" data-toggle="collapse">
                     <div class="row title">
                       <div class="col-md-12">
                         <h3 class="center">Microsoft Office 365 Features</h3>
                       </div>
                     </div>
                   </a>
-                    <div id="features-mobile-enterprise-3" class="collapse">
-                      <div class="row">
-                        <div class="col-md-12">
+                    <div id="features-mobile-enterprise-1" class="collapse">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
@@ -2117,16 +1764,16 @@
                       </div>
                     </div>
                   </div>
-                    <a href="#advanced-mobile-enterprise-3" data-toggle="collapse">
+                    <a href="#advanced-mobile-enterprise-1" data-toggle="collapse">
                     <div class="row title">
                       <div class="col-md-12">
                         <h3 class="center">Advanced Features/Benefits</h3>
                       </div>
-                    </div>
+                  </div>
                   </a>
-                    <div id="advanced-mobile-enterprise-3" class="collapse">
-                      <div class="row">
-                        <div class="col-md-12">
+                    <div id="advanced-mobile-enterprise-1" class="collapse">
+                    <div class="row">
+                      <div class="col-md-12">
                         <table>
                           <tbody>
                             <tr>
@@ -2170,13 +1817,12 @@
                             </tr>
                             <tr>
                               <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
-                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a></td>
+                              <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/be:5" class="button lead">Try Now</a></td>
                             </tr>
                           </tbody>
                         </table>
                       </div>
                     </div>
-                  </div>
                     <div class="row half-padding">
                       <div class="col-md-12">
                         <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
@@ -2186,529 +1832,884 @@
                       </div>
                     </div>
                   </div>
+                  </div>
                 </div>
               </div>
-          </div>
-          <div class="hidden-xs hidden-sm">
-            <div class="row price-compare">
-              <div class="col-md-3">
-                <p><strong>Price</strong><br/>
-                    Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong></p><br/>
-              </div>
-              <div class="col-md-9">
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>11</h1>
-                    <p class="center">user/month</p>
-                  </div>
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>12</h1>
-                    <p class="center">user/month</p>
-                  </div>
-                  <div class="col-md-4">
-                    <h1><sup>$</sup>23</h1>
-                    <p class="center">user/month</p>
-                  </div>
-                  <div class="col-md-12 half-padding">
-                    <h5 class="center">Call 1-855-715-7307</h5>
-                    <div class="col-md-4 center-block">
-                      <a href="#chat" class="button lead center-block">Chat</a>
+              <div class="col-md-3 pricing">
+                  <div class="panel panel-pricing">
+                      <div class="panel-heading">
+                        <h3 class="left">Enterprise <br/>ProPlus</h3>
+                        <hr class="white" style="margin-top: 5px;"/>
+                        <p><strong>Office 2016</strong><br/>
+                          Full desktop, online and mobile versions of Office<br/></p>
+                      </div>
+                      <div class="panel-body pricing hidden-md hidden-lg">
+                    <div class="row">
+                        <div class="col-md-12">
+                          <p><strong>What's<br/> Included</strong><br/>
+                            Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                        </div>
+                      </div>
+                      <div class="row">
+                        <div class="col-xs-6">
+                          <p class="left"><strong>Maximum Users per Plan</strong></p>
+                        </div>
+                        <div class="col-xs-6">
+                          <p class="right semi-bold center">Unlimited</p>
+                        </div>
+                      </div>
+                      <a href="#support-mobile-enterprise-2" data-toggle="collapse">
+                        <div class="row title">
+                          <div class="col-md-12">
+                            <h3 class="center">Fanatical Support from Rackspace</h3>
+                          </div>
+                        </div>
+                      </a>
+                      <div id="support-mobile-enterprise-2" class="collapse in">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p class="semi-bold">Unlimited 24x7x365
+    U.S.-based support</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Free email migrations to Office 365</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Rapid Managed Escalation</strong><br/>
+                                  We work directly with Microsoft to resolve your problems quickly</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#features-mobile-enterprise-2" data-toggle="collapse">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3 class="center">Microsoft Office 365 Features</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="features-mobile-enterprise-2" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Fully installed Office applications</strong><br/>
+                                  Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
+                                  1TB file storage per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Office 2016 on tablets and phones</strong><br/>
+                                  For the full Office experience on mobile devices</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Exchange</strong><br/>
+                                  Business-class email, contacts, calendar and 50GB mailboxes</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>SharePoint and Skype for Business</strong><br/>
+                                  Team sites, online meetings, chat, voice and video calls</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Online versions of Office 2016</strong><br/>
+                                  Including Word, Excel and PowerPoint</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#advanced-mobile-enterprise-2" data-toggle="collapse">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3 class="center">Advanced Features/Benefits</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="advanced-mobile-enterprise-2" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Yammer</strong><br/>
+                                  Corporate social network to help employees collaborate across departments and locations</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Delve</strong><br/>
+                                  Personalized search and discovery across Office 365 </p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Active Directory Integration</strong></p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Compliance</strong><br/>
+                                  Native archiving, eDiscovery and mailbox holds</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Azure Rights Management</strong><br/>
+                                  Message encryption, Information Rights Management, Data Loss Prevention</p></td>
+                                <td>Optional</td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Enterprise Management</strong><br/>
+                                  Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Advanced Skype for Business</strong><br/>
+                                  Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Intranet site for your teams</strong><br/>
+                                  With customizable security settings</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
+                                <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bo:5" class="button lead">Try Now</a></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <div class="row half-padding">
+                        <div class="col-md-12">
+                          <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
+                        </div>
+                        <div class="col-md-12">
+                          <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+                        </div>
+                      </div>
                     </div>
                   </div>
-                  <div class="col-md-12 title">
-                    <h5 class="center">No Long-Term Contract Required</h5>
+              </div>
+              <div class="col-md-3 pricing">
+              <div class="panel panel-pricing">
+                <div class="panel-heading enterprise">
+                  <br/>
+                   <h3 class="white left">Enterprise E3</h3>
+                   <hr class="white"/>
+                   <p class="white"><strong>Email + Office 2016</strong><br/>
+                    All features from E1 and ProPlus, plus advanced Enterprise tools</p>
+                </div>
+                <div class="panel-body pricing hidden-md hidden-lg">
+                  <div class="row">
+                        <div class="col-md-12">
+                          <p><strong>What's<br/> Included</strong><br/>
+                            Every plan comes with FREE email migration, 24x7x365 Fanatical Support<sup>&reg;</sup> and expertise to help you get the most out of Office 365. Start with a 14-day free trial.</p>
+                        </div>
+                      </div>
+                      <div class="row">
+                        <div class="col-xs-6">
+                          <p class="left"><strong>Maximum Users per Plan</strong></p>
+                        </div>
+                        <div class="col-xs-6">
+                          <p class="right semi-bold center">Unlimited</p>
+                        </div>
+                      </div>
+                      <a href="#support-mobile-enterprise-3" data-toggle="collapse">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3 class="center">Fanatical Support from Rackspace</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="support-mobile-enterprise-3" class="collapse in">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p class="semi-bold">Unlimited 24x7x365
+    U.S.-based support</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Free email migrations to Office 365</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p class="semi-bold">Access to top tier Office 365 experts</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Rapid Managed Escalation</strong><br/>
+                                  We work directly with Microsoft to resolve your problems quickly</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#features-mobile-enterprise-3" data-toggle="collapse">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3 class="center">Microsoft Office 365 Features</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="features-mobile-enterprise-3" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Fully installed Office applications</strong><br/>
+                                  Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup> — on up to 5 PCs or Macs per user</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>skydrive<sup>&reg;</sup></strong><br/>
+                                  1TB file storage per user</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Office 2016 on tablets and phones</strong><br/>
+                                  For the full Office experience on mobile devices</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Exchange</strong><br/>
+                                  Business-class email, contacts, calendar and 50GB mailboxes</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>SharePoint and Skype for Business</strong><br/>
+                                  Team sites, online meetings, chat, voice and video calls</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Online versions of Office 2016</strong><br/>
+                                  Including Word, Excel and PowerPoint</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <a href="#advanced-mobile-enterprise-3" data-toggle="collapse">
+                      <div class="row title">
+                        <div class="col-md-12">
+                          <h3 class="center">Advanced Features/Benefits</h3>
+                        </div>
+                      </div>
+                    </a>
+                      <div id="advanced-mobile-enterprise-3" class="collapse">
+                        <div class="row">
+                          <div class="col-md-12">
+                          <table>
+                            <tbody>
+                              <tr>
+                                <td><p><strong>Yammer</strong><br/>
+                                  Corporate social network to help employees collaborate across departments and locations</p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Delve</strong><br/>
+                                  Personalized search and discovery across Office 365 </p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Active Directory Integration</strong></p></td>
+                                <td><i class="fa fa-check check"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Compliance</strong><br/>
+                                  Native archiving, eDiscovery and mailbox holds</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Azure Rights Management</strong><br/>
+                                  Message encryption, Information Rights Management, Data Loss Prevention</p></td>
+                                <td>Optional</td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Enterprise Management</strong><br/>
+                                  Of apps with Group Policy, Telemetry, Shared Computer Activation</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Advanced Skype for Business</strong><br/>
+                                  Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><p><strong>Intranet site for your teams</strong><br/>
+                                  With customizable security settings</p></td>
+                                <td><i class="fa fa-times times"></i></td>
+                              </tr>
+                              <tr>
+                                <td><h5>No Long-Term Contract<br/>Start a 14-Day Free Trial</h5></td>
+                                <td class="lead-cell"><a href="https://cart.rackspace.com/office365/signups/chooseApps/bp:5" class="button lead">Try Now</a></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                      <div class="row half-padding">
+                        <div class="col-md-12">
+                          <h5 class="center">The best part about all of our plans? They come with our 24x7x365 Fanatical Support.</h5>
+                        </div>
+                        <div class="col-md-12">
+                          <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            <div class="row border">
-              <div class="col-md-3">
-                <p class="semi-bold">Maximum Users per Plan</p>
-              </div>
-              <div class="col-md-9">
-                <div class="row">
-                  <div class="col-md-4">
-                    <p class="semi-bold center">Unlimited</p>
-                  </div>
-                  <div class="col-md-4">
-                    <p class="semi-bold center">Unlimited</p>
-                  </div>
-                  <div class="col-md-4">
-                    <p class="semi-bold center">Unlimited</p>
-                  </div>
-                </div>
-              </div>
             </div>
-            <div class="row">
-              <div class="col-md-3">
-                <p class="semi-bold">What’s<br/> Included<br/><br/></p>
-              </div>
-              <div class="col-md-9">
-                <div class="row">
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                    </ul>
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                    </ul>
-                  </div>
-                  <div class="col-md-4">
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
-                    </ul>
-                    <ul class="product-icons">
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
-                      <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#support" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                  <h4 class="center">Fanatical Support from Rackspace</h4>
-                </div>
-              </div>
-            </a>
-            <div id="support" class="collapse in">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Unlimited 24x7x365<br />U.S.-based support</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Free email migrations to Office 365</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p class="semi-bold">Access to top tier Office 365 experts</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Rapid Managed Escalation</strong><br/>
-                        We work directly with Microsoft to resolve your problems quickly</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#features" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                  <h4 class="center">Microsoft Office 365 Features</h4>
-                </div>
-              </div>
-            </a>
-            <div id="features" class="collapse">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Fully installed Office applications</strong><br/>
-                        Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i><br/>
-                          <p class="small center">Plus Microsoft Access</p>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i><br/>
-                          <p class="small center">Plus Microsoft Access</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>OneDrive<sup>&reg;</sup></strong><br/>
-                        1TB file storage per user</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i><br/>
-                          <p class="small center">Unlimited Storage</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Office 2016 on tablets and phones </strong><br/>
-                        For the full Office experience on mobile devices</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Exchange</strong><br/>
-                        Business-class email, contacts, calendar and 50GB mailboxes</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>SharePoint and Skype for Busines</strong><br/>
-                        Team sites, online meetings, chat, voice and video calls</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Online versions of Office 2016</strong><br/>
-                        Including Word, Excel and PowerPoint</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a href="#advanced" data-toggle="collapse">
-              <div class="row title">
-                <div class="col-md-1">
-                  <i class="fa fa-arrow-right"></i>
-                </div>
-                <div class="col-md-11">
-                  <h4 class="center">Advanced Features/Benefits</h4>
-                </div>
-              </div>
-            </a>
-            <div id="advanced" class="collapse">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Yammer</strong><br/>
-                        Corporate social network to help employees collaborate across departments and locations</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Delve</strong><br/>
-                        Personalized search and discovery across Office 365 </p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Active Directory Integration</strong></p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-check check"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Compliance</strong><br/>
-                        Native Archiving, eDiscovery and mailbox holds</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Azure Rights Management</strong><br/>
-                        Message encryption, Information Rights Management, Data Loss Prevention</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                        <div class="col-md-4">
-                          <p class="gray-light center">Optional</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Enterprise Management </strong><br/>
-                        Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Advanced Skype for Business</strong><br/>
-                        Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="row border centered row-eq-height">
-                    <div class="col-md-3">
-                      <p><strong>Intranet site for your teams </strong><br/>
-                        With customizable security settings</p>
-                    </div>
-                    <div class="col-md-9">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                        <div class="col-md-4">
-                          <i class="fa fa-times times"></i>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row border centered row-eq-height">
+            <div class="hidden-xs hidden-sm">
+              <div class="row price-compare">
                 <div class="col-md-3">
-                  <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
+                  <p><strong>Price</strong><br/>
+                      Every plan comes with FREE email migration, 24x7x365 <strong>Fanatical Support<sup>&reg;</sup></strong> and expertise to help you get the most out of Office 365. <strong>Start with a 14-day free trial.</strong></p><br/>
+                </div>
+                <div class="col-md-9">
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>11</h1>
+                      <p class="center">user/month</p>
+                    </div>
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>12</h1>
+                      <p class="center">user/month</p>
+                    </div>
+                    <div class="col-md-4">
+                      <h1><sup>$</sup>23</h1>
+                      <p class="center">user/month</p>
+                    </div>
+                    <div class="col-md-12 half-padding">
+                      <h5 class="center">Call 1-855-715-7307</h5>
+                      <div class="col-md-4 center-block">
+                        <a href="#chat" class="button lead center-block">Chat</a>
+                      </div>
+                    </div>
+                    <div class="col-md-12 title">
+                      <h5 class="center">No Long-Term Contract Required</h5>
+                    </div>
+                  </div>
+                </div>
+              <div class="row border">
+                <div class="col-md-3">
+                  <p class="semi-bold">Maximum Users per Plan</p>
                 </div>
                 <div class="col-md-9">
                   <div class="row">
                     <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
+                      <p class="semi-bold center">Unlimited</p>
                     </div>
                     <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
+                      <p class="semi-bold center">Unlimited</p>
                     </div>
                     <div class="col-md-4">
-                        <div class="col-md-8 center-block">
-                            <a href="#chat" class="button lead">Chat</a>
-                        </div>
+                      <p class="semi-bold center">Unlimited</p>
                     </div>
                   </div>
                 </div>
-            </div>
-            <div class="row">
-              <div class="col-md-8 center-block half-padding">
-                <h4 class="center">The best part about all of our plans?<br/>
-                  They come with our 24x7x365 Fanatical Support.</h4>
-                <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+              </div>
+              <div class="row">
+                <div class="col-md-3">
+                  <p class="semi-bold">What’s<br/> Included<br/><br/></p>
+                </div>
+                <div class="col-md-9">
+                  <div class="row">
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                      </ul>
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                      </ul>
+                    </div>
+                    <div class="col-md-4">
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/office-365/fanatiguy.png"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/exchange.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/outlook.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/n.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/word.svg"></li>
+                      </ul>
+                      <ul class="product-icons">
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/p.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/powerpoint.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/excel.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skydrive.svg"></li>
+                        <li><img src="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/office-365/products/skype.svg"></li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#support" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                    <h4 class="center">Fanatical Support from Rackspace</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="support" class="collapse in">
+                <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Unlimited 24x7x365<br />U.S.-based support</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Free email migrations to Office 365</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p class="semi-bold">Access to top tier Office 365 experts</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Rapid Managed Escalation</strong><br/>
+                          We work directly with Microsoft to resolve your problems quickly</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#features" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                    <h4 class="center">Microsoft Office 365 Features</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="features" class="collapse">
+                <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Fully installed Office applications</strong><br/>
+                          Word<sup>&reg;</sup>, Excel<sup>&reg;</sup>, PowerPoint<sup>&reg;</sup>, Outlook<sup>&reg;</sup>, Publisher<sup>&reg;</sup>, OneNote<sup>&reg;</sup>— on up to 5 PCs or Macs per user</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i><br/>
+                            <p class="small center">Plus Microsoft Access</p>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i><br/>
+                            <p class="small center">Plus Microsoft Access</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>OneDrive<sup>&reg;</sup></strong><br/>
+                          1TB file storage per user</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i><br/>
+                            <p class="small center">Unlimited Storage</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Office 2016 on tablets and phones </strong><br/>
+                          For the full Office experience on mobile devices</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Exchange</strong><br/>
+                          Business-class email, contacts, calendar and 50GB mailboxes</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>SharePoint and Skype for Busines</strong><br/>
+                          Team sites, online meetings, chat, voice and video calls</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Online versions of Office 2016</strong><br/>
+                          Including Word, Excel and PowerPoint</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <a href="#advanced" data-toggle="collapse">
+                <div class="row title">
+                  <div class="col-md-1">
+                    <i class="fa fa-arrow-right"></i>
+                  </div>
+                  <div class="col-md-11">
+                    <h4 class="center">Advanced Features/Benefits</h4>
+                  </div>
+                </div>
+              </a>
+              <div id="advanced" class="collapse">
+                <div class="row">
+                  <div class="col-md-12">
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Yammer</strong><br/>
+                          Corporate social network to help employees collaborate across departments and locations</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Delve</strong><br/>
+                          Personalized search and discovery across Office 365 </p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Active Directory Integration</strong></p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-check check"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Compliance</strong><br/>
+                          Native Archiving, eDiscovery and mailbox holds</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Azure Rights Management</strong><br/>
+                          Message encryption, Information Rights Management, Data Loss Prevention</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                          <div class="col-md-4">
+                            <p class="gray-light center">Optional</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Enterprise Management </strong><br/>
+                          Of apps with Group Policy, Telemetry, Shared Computer Activation</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Advanced Skype for Business</strong><br/>
+                          Meetings broadcast on the Internet to up to 10,000 people who can attend in a browser on nearly any device</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row border centered row-eq-height">
+                      <div class="col-md-3">
+                        <p><strong>Intranet site for your teams </strong><br/>
+                          With customizable security settings</p>
+                      </div>
+                      <div class="col-md-9">
+                        <div class="row">
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                          <div class="col-md-4">
+                            <i class="fa fa-times times"></i>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row border centered row-eq-height">
+                  <div class="col-md-3">
+                    <p><strong>No Long-Term Contract Start a 14-Day Free Trial</strong></p>
+                  </div>
+                  <div class="col-md-9">
+                    <div class="row">
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                      <div class="col-md-4">
+                          <div class="col-md-8 center-block">
+                              <a href="#chat" class="button lead">Chat</a>
+                          </div>
+                      </div>
+                    </div>
+                  </div>
+              </div>
+              <div class="row">
+                <div class="col-md-8 center-block half-padding">
+                  <h4 class="center">The best part about all of our plans?<br/>
+                    They come with our 24x7x365 Fanatical Support.</h4>
+                  <a href="[rs_link:office-365:fanatical-support]" class="button learning center-block">Explore Fanatical Support</a>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- End Overview - Features -->
+    <!-- End Overview - Features -->
+  </div>
 </div>

--- a/styleguide/derek/examples/section-overview.ejs
+++ b/styleguide/derek/examples/section-overview.ejs
@@ -1,23 +1,23 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
+<div class="contentOffset">
+  <%- partial("../_partials/solutions/header-large.ejs") %>
 
-<%- partial("../_partials/solutions/header-large.ejs") %>
+  <%- partial("../_partials/solutions/lead.ejs") %>
 
-<%- partial("../_partials/solutions/lead.ejs") %>
+  <p class="semi-bold red center half-padding-top">Key Offers and infrastructure and services are interchangable or both can be kept if needed.</p>
 
-<p class="semi-bold red center half-padding-top">Key Offers and infrastructure and services are interchangable or both can be kept if needed.</p>
+  <%- partial("../_partials/solutions/services-3-col.ejs") %>
 
-<%- partial("../_partials/solutions/services-3-col.ejs") %>
+  <%- partial("../_partials/solutions/key-offers.ejs") %>
 
-<%- partial("../_partials/solutions/key-offers.ejs") %>
-
-<div class="container standard-padding-full">
-  <div class="row">
-    <div class="col-md-12">
-      <p>OPTIONAL: Available Space for mini panel layout or text area. Can include: video, text, features or ideogram within 50/50 grid. Should not require any custom markup. Should be informative and differintiating for your product or campaign.</p>
+  <div class="container standard-padding-full">
+    <div class="row">
+      <div class="col-md-12">
+        <p>OPTIONAL: Available Space for mini panel layout or text area. Can include: video, text, features or ideogram within 50/50 grid. Should not require any custom markup. Should be informative and differintiating for your product or campaign.</p>
+      </div>
     </div>
   </div>
+  <hr>
+  <%- partial("../_partials/solutions/cta.ejs") %>
 </div>
-<hr>
-<%- partial("../_partials/solutions/cta.ejs") %>
-

--- a/styleguide/derek/examples/swatches.ejs
+++ b/styleguide/derek/examples/swatches.ejs
@@ -1,183 +1,185 @@
 <%- partial("../_partials/_ceiling") %>
 <%- partial("../_partials/_mainnav") %>
-<div class="bg-light-gray">
-  <div class="container standard-padding">
-    <div class="row">
-      <div class="col-md-12">
-        <h4>Primary Colors</h4>
-      </div>
-    </div>
-    <div class="row row-eq-height">
-      <div class="col-sm-3 col-xs-6 swatch">
-        <div class="swatch-color bg-red">
-          <div class="swatch-copy-button">
-            <input id="swatch-copy" class="swatch-copy" value="c40022" type="text"/>
-            <a data-copytarget="#swatch-copy">Copy</a>
-          </div>
-        </div>
-        <div class="swatch-footer">
-          <h6>$brand-primary</h6>
-          <h6>#c40022</h6>
+<div class="contentOffset">
+  <div class="bg-light-gray">
+    <div class="container standard-padding">
+      <div class="row">
+        <div class="col-md-12">
+          <h4>Primary Colors</h4>
         </div>
       </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color signup-green">
-          <div class="swatch-color-lighter signup-green" data-toggle="tooltip" data-placement="right" title="Hover State lighten($brand-success, 5%)"></div>
-          <div class="swatch-copy-button">
-              <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+      <div class="row row-eq-height">
+        <div class="col-sm-3 col-xs-6 swatch">
+          <div class="swatch-color bg-red">
+            <div class="swatch-copy-button">
+              <input id="swatch-copy" class="swatch-copy" value="c40022" type="text"/>
               <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$brand-primary</h6>
+            <h6>#c40022</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$brand-success</h6>
-          <h6>#5aaa28</h6>
-        </div>
-      </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color bg-medium-teal">
-          <div class="swatch-color-darker mediumteal"></div>
-          <div class="swatch-copy-button">
-            <input id="swatch-copy" class="swatch-copy" value="0DCFD9" type="text"/>
-            <a data-copytarget="#swatch-copy" class="center">Copy</a>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color signup-green">
+            <div class="swatch-color-lighter signup-green" data-toggle="tooltip" data-placement="right" title="Hover State lighten($brand-success, 5%)"></div>
+            <div class="swatch-copy-button">
+                <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+                <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$brand-success</h6>
+            <h6>#5aaa28</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$brand-secondary</h6>
-          <h6>#0DCFD9</h6>
-        </div>
-      </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color bg-blue-gray">
-          <div class="swatch-copy-button">
-            <input id="swatch-copy" class="swatch-copy" value="2e3238" type="text"/>
-            <a data-copytarget="#swatch-copy" class="center">Copy</a>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color bg-medium-teal">
+            <div class="swatch-color-darker mediumteal"></div>
+            <div class="swatch-copy-button">
+              <input id="swatch-copy" class="swatch-copy" value="0DCFD9" type="text"/>
+              <a data-copytarget="#swatch-copy" class="center">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$brand-secondary</h6>
+            <h6>#0DCFD9</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$blue-gray</h6>
-          <h6>#2e3238</h6>
-        </div>
-      </div>
-    </div>
-    <div class="row half-padding-top">
-      <div class="col-md-12">
-        <h4>Accent Colors</h4>
-      </div>
-    </div>
-    <div class="row row-eq-height">
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color mustard">
-          <div class="swatch-color-lighter mustard"></div>
-          <div class="swatch-color-darker mustard"></div>
-          <div class="swatch-copy-button">
-              <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
-              <a data-copytarget="#swatch-copy">Copy</a>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color bg-blue-gray">
+            <div class="swatch-copy-button">
+              <input id="swatch-copy" class="swatch-copy" value="2e3238" type="text"/>
+              <a data-copytarget="#swatch-copy" class="center">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$blue-gray</h6>
+            <h6>#2e3238</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$mustard</h6>
-          <h6>#f6b100</h6>
+      </div>
+      <div class="row half-padding-top">
+        <div class="col-md-12">
+          <h4>Accent Colors</h4>
         </div>
       </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color magento-orange">
-          <div class="swatch-copy-button">
-              <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
-              <a data-copytarget="#swatch-copy">Copy</a>
+      <div class="row row-eq-height">
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color mustard">
+            <div class="swatch-color-lighter mustard"></div>
+            <div class="swatch-color-darker mustard"></div>
+            <div class="swatch-copy-button">
+                <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+                <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$mustard</h6>
+            <h6>#f6b100</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$orange</h6>
-          <h6>#ed672f</h6>
-        </div>
-      </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color purple">
-          <div class="swatch-copy-button">
-              <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
-              <a data-copytarget="#swatch-copy">Copy</a>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color magento-orange">
+            <div class="swatch-copy-button">
+                <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+                <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$orange</h6>
+            <h6>#ed672f</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$purple</h6>
-          <h6>#784b91</h6>
-        </div>
-      </div>
-      <div class="col-sm-3 col-xs-6">
-        <div class="swatch-color bg-steel-blue">
-          <div class="swatch-copy-button">
-              <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
-              <a data-copytarget="#swatch-copy">Copy</a>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color purple">
+            <div class="swatch-copy-button">
+                <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+                <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$purple</h6>
+            <h6>#784b91</h6>
           </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$blue-steel</h6>
-          <h6>#007295</h6>
+        <div class="col-sm-3 col-xs-6">
+          <div class="swatch-color bg-steel-blue">
+            <div class="swatch-copy-button">
+                <input id="swatch-copy" class="swatch-copy" value="5aaa28" type="text"/>
+                <a data-copytarget="#swatch-copy">Copy</a>
+            </div>
+          </div>
+          <div class="swatch-footer">
+            <h6>$blue-steel</h6>
+            <h6>#007295</h6>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="row half-padding-top">
-      <div class="col-md-12">
-        <h4>Grays</h4>
-      </div>
-    </div>
-    <div class="row row-eq-height">
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color bg-light-gray">
-        </div>
-        <div class="swatch-footer">
-          <h6>$gray-lightest</h6>
-          <h6>#efefef</h6>
+      <div class="row half-padding-top">
+        <div class="col-md-12">
+          <h4>Grays</h4>
         </div>
       </div>
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color gray-light">
+      <div class="row row-eq-height">
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color bg-light-gray">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-lightest</h6>
+            <h6>#efefef</h6>
+          </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$gray-lighter</h6>
-          <h6>#dedede</h6>
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color gray-light">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-lighter</h6>
+            <h6>#dedede</h6>
+          </div>
         </div>
-      </div>
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color gray-base">
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color gray-base">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-base</h6>
+            <h6>#666</h6>
+          </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$gray-base</h6>
-          <h6>#666</h6>
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color gray-darker">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-darker</h6>
+            <h6>#4c4c4c</h6>
+          </div>
         </div>
-      </div>
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color gray-darker">
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color bg-dark-gray">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-darkest</h6>
+            <h6>#333</h6>
+          </div>
         </div>
-        <div class="swatch-footer">
-          <h6>$gray-darker</h6>
-          <h6>#4c4c4c</h6>
-        </div>
-      </div>
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color bg-dark-gray">
-        </div>
-        <div class="swatch-footer">
-          <h6>$gray-darkest</h6>
-          <h6>#333</h6>
-        </div>
-      </div>
-      <div class="col-sm-2 col-xs-6">
-        <div class="swatch-color darkest-gray">
-        </div>
-        <div class="swatch-footer">
-          <h6>$gray-darkest</h6>
-          <h6>#2a2a2a</h6>
+        <div class="col-sm-2 col-xs-6">
+          <div class="swatch-color darkest-gray">
+          </div>
+          <div class="swatch-footer">
+            <h6>$gray-darkest</h6>
+            <h6>#2a2a2a</h6>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="container">
-    <div class="row standard-padding">
-      <div class="col-md-12">
-        <h4>Available River Colors</h4>
-        <%- partial('../_partials/solutions/rivers.ejs') %>
+  <div class="container">
+      <div class="row standard-padding">
+        <div class="col-md-12">
+          <h4>Available River Colors</h4>
+          <%- partial('../_partials/solutions/rivers.ejs') %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds ```<div class="contentOffset">``` to example pages on zoolander to account for navigation height at top of page. 

*DOES NOT AFFECT www

ex: 
http://localhost:9000/derek/examples/events-interior
http://localhost:9000/derek/examples/events
http://localhost:9000/derek/examples/homepage
http://localhost:9000/derek/examples/office365
http://localhost:9000/derek/examples/section-overview
http://localhost:9000/derek/examples/swatches