### PR TITLE
RSWEB-7703: Fix lead text alignment in mini panels

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -16,7 +16,8 @@
   margin-bottom: 1em;
 
   .lead,
-  .lead-title  {
+  .lead-title,
+  .lead-text {
     text-align: left;
   }
 


### PR DESCRIPTION
This was broke. I fixed it. 