### PR TITLE
style(rsweb-7848-title-case): remove uppercase from headings

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -82,6 +82,7 @@ $banner-text-margin-medium: 10%;
   font-weight: 700;
   line-height: .9em;
   margin: 0;
+  text-transform: uppercase;
 }
 
 .imacBanner-textContainer {

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -12,7 +12,6 @@ $font-weight-black: 600;
   color: $color;
   font-family: $heading;
   font-weight: $font-weight-black;
-  text-transform: uppercase;
 }
 
 @mixin subhead($color: $gray-darkest) {


### PR DESCRIPTION
This PR converts headings to title case by removing the text-transform attribute from the headings mixin and adding it to the imacBanner-heading to ensure we retained uppercase for our banners. 