### PR TITLE
RSWEB-7085: Sass-lint nesting issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:visual:init": "nohup npm start & (cd ./node_modules/backstopjs && npm run reference)",
     "backstop-update": "node ./scripts/update-backstop-urls.js",
     "sass:compile": "node-sass --output-style=compressed --quiet -o /tmp styleguide/css",
-    "sass-lint": "sass-lint -v --max-warnings 19",
+    "sass-lint": "sass-lint -v --max-warnings 13",
     "hooks": "./scripts/hooks.sh",
     "postinstall": "npm run hooks"
   },

--- a/styleguide/_themes/derek/scss/snowflakes/homepage.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/homepage.scss
@@ -1,49 +1,3 @@
-#hosting-options {
-  text-align: center;
-
-  .product {
-
-    p {
-      margin-bottom: 30px;
-    }
-
-    &:hover {
-      background-color: $gray-lightest;
-
-      hr {
-        border-color: $brand-secondary;
-	  }
-
-      h3,
-      a {
-        color: $brand-secondary;
-	  }
-    }
-  }
-}
-
-#solutions {
-
-  a {
-    text-decoration: none;
-  }
-
-  .solution {
-    &:hover {
-      .border-white {
-        border-color: $mustard;
-
-        i {
-          color: $mustard;
-        }
-      }
-    }
-  }
-}
-
-
-//new code
-
 .clear-container {
   @include make-sm-column(6);
   clear: both;
@@ -292,4 +246,3 @@
     width: 50%;
   }
 }
-

--- a/styleguide/_themes/derek/scss/snowflakes/o365.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/o365.scss
@@ -67,16 +67,14 @@ a {
     vertical-align: middle;
   }
 
-  tr {
-    td {
-      &.col-md-2 {
-        border: 1px solid $gray-lightest;
-        padding: 20px 15px;
-        width: 14%;
+  tr > td {
+    &.col-md-2 {
+      border: 1px solid $gray-lightest;
+      padding: 20px 15px;
+      width: 14%;
 
-        &:first-child {
-          width: 15.79%;
-        }
+      &:first-child {
+        width: 15.79%;
       }
     }
   }

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -97,21 +97,17 @@ ul {
   list-style: none;
   padding-left: 1.3em;
 
-  &.teal {
-    li {
-      &::before {
-        color: $teal-dark;
-      }
+  &.teal > li {
+    &::before {
+      color: $teal-dark;
     }
   }
 
-  &.green {
-    li {
-      &::before {
-        color: $brand-success;
-        }
-      }
+  &.green > li {
+    &::before {
+      color: $brand-success;
     }
+  }
 
   li {
     list-style: none;


### PR DESCRIPTION
This PR addresses `warning  Nesting depth 3 greater than max of 2  nesting-depth` sass lint errors on the following files.  Here is how I did it. A few assumptions were made so this will need to be verified separately. 

- homepage.scss: I just removed all of the old style code as its no longer used. @amberRrucker is this correct? 
- o365.scss: By forcing `td` to be a direct child of `tr`, it removes a level of nesting from sass-lint's perspective.
- fonts.scss: By forcing `li` to be a direct child of `.green` or `.teal` lists, it removes a level of nesting from sass-lint's perspective.

An important thing to note is that I left the nesting issues on the `tabs.scss` file. The reason for this is that the tabs are getting refactored next couple of sprints, so we can just let that process handle the cleanup of those errors instead as it is likely to be all brand new code.