### PR TITLE
RSWEB-7921: min height for row to be at least two lines

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/cards/resources.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/resources.scss
@@ -107,6 +107,7 @@
   .row-eq-height {
     flex-grow: 2;
     margin: 10px;
+    min-height: 7.8rem;
   }
 }
 


### PR DESCRIPTION
Sets min height for Additional Resources pattern to be at least 2 lines tall. 

http://localhost:9000/derek/solutions/solutions

`.additional-resource .row-eq-height { min-height: 78px; }`
