### PR TITLE
RSWEB-7996: Remove partner/developer links

### DIFF
--- a/styleguide/derek/_partials/_ceiling.ejs
+++ b/styleguide/derek/_partials/_ceiling.ejs
@@ -21,12 +21,6 @@
           </nav>
           <nav class="ceiling-menuNav">
               <ul class="ceiling-menuInline" role="menu">
-                  <li class="ceiling-menuInline-item">
-                      <a href="/developers" class="ceiling-menuInline-link" role="menuitem" title="Developers">Developers</a>
-                  </li>
-                  <li class="ceiling-menuInline-item ceiling-menuInline-itemPartners">
-                      <a href="/partners" class="ceiling-menuInline-link" role="menuitem" title="Partners">Partners</a>
-                  </li>
                   <li class="ceiling-menuInline-item ceiling-dropdown">
                       <a href="javascript:" class="dropdown-toggle ceiling-dropdownToggle ceiling-dropdownToggle-green" data-toggle="dropdown" role="button" aria-expanded="false">Sign up</a>
                       <ul class="ceiling-dropdownMenu ceiling-dropdownMenu-green" role="menu">


### PR DESCRIPTION
This PR removes the developer and partner links from the ceiling. This work technically only needs to be done on www, but I did it here as well for consistency.