### PR TITLE
RSWEB-7811: Remove row and adjust width for features

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/cards/productFeatures.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/productFeatures.scss
@@ -1,6 +1,6 @@
 .features-wrapper {
   @include flex-box;
-  margin-bottom: 1em;
+  width: 100%;
 
   &.features-threeUp {
     display: block;

--- a/styleguide/derek/_partials/cards/product-feature.ejs
+++ b/styleguide/derek/_partials/cards/product-feature.ejs
@@ -2,14 +2,12 @@
 <% if(!desc) { var desc = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis."; } %>
 <!-- Product Features Pattern -->
 <div class="features-wrapper">
-  <div class="row row-eq-height">
-    <div class="col-md-2 features-icon">
-      <i class="rsweb srv-design-build"></i>
-    </div>
-    <div class="col-md-10 features-desc">
-      <h4>Example Title</h4>
-      <a href="javascript:void(0)">This is an example of a link in the Feature pattern.</a>
-      <p><%- desc %></p>
-    </div>
+  <div class="col-md-2 features-icon">
+    <i class="rsweb srv-design-build"></i>
+  </div>
+  <div class="col-md-10 features-desc">
+    <h4>Example Title</h4>
+    <a href="javascript:void(0)">This is an example of a link in the Feature pattern.</a>
+    <p><%- desc %></p>
   </div>
 </div>

--- a/styleguide/derek/layouts/features.ejs
+++ b/styleguide/derek/layouts/features.ejs
@@ -1,24 +1,38 @@
 <!-- Features: 50/50 -->
-<div class="bg-light-gray">
+<div class="bg-light-gray half-padding">
   <div class="container">
-    <div class="row">
+    <div class="row row-eq-height">
+      <div class="col-sm-6 panel-flex">
+        <div class="subpanel panel-flex">
+          <div class="subpanel-inner panel-flex">
+            <%- partial('../_partials/cards/product-feature') %>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 panel-flex">
+        <div class="subpanel panel-flex">
+          <div class="subpanel-inner panel-flex">
+            <%- partial('../_partials/cards/product-feature', {
+            desc: 'consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean m'
+            }) %>
+          </div>
+        </div>
+      </div>
     </div>
     <div class="row row-eq-height">
       <div class="col-sm-6 panel-flex">
-        <%- partial('../_partials/cards/product-feature') %>
+        <div class="subpanel panel-flex">
+          <div class="subpanel-inner panel-flex">
+            <%- partial('../_partials/cards/product-feature', { desc: 'consectetuer' }) %>
+          </div>
+        </div>
       </div>
       <div class="col-sm-6 panel-flex">
-        <%- partial('../_partials/cards/product-feature', {
-        desc: 'consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean m'
-      }) %>
-      </div>
-    </div>
-    <div class="row row-eq-height">
-      <div class="col-sm-6 panel-flex">
-        <%- partial('../_partials/cards/product-feature') %>
-      </div>
-      <div class="col-sm-6 panel-flex">
-        <%- partial('../_partials/cards/product-feature') %>
+        <div class="subpanel panel-flex">
+          <div class="subpanel-inner panel-flex">
+            <%- partial('../_partials/cards/product-feature') %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/styleguide/derek/solutions/solutions.ejs
+++ b/styleguide/derek/solutions/solutions.ejs
@@ -37,6 +37,7 @@
 <%- partial('../layouts/awards.ejs') %>
 <%- partial('../layouts/additional-resources.ejs') %>
 <%- partial('../layouts/business-resources.ejs') %>
+<%- partial('../layouts/features.ejs') %>
 <%- partial('../_partials/solutions/tabs.ejs') %>
 <%- partial('../layouts/lists.ejs') %>
 <%- partial('../layouts/announcements.ejs') %>


### PR DESCRIPTION
This PR fixes a few layout issues with features:

1.) Adds `width: 100%;` to the pattern wrapper.
2.) Remove the `<div class="row row-eq-height">` from inside the pattern. This has to be done on the `www` side as well. 
3.) Removed the margin-bottom from the features pattern, as all margins/patterns between panes is now handled by the layouts instead of the pattern itself.
4.) Added `subpanel` and `subpanel-inner` classes to get zoolander markup to match up with www.
5.) Added the features pattern to the solutions page as it was missing. 

Note: Because this is just a bug fix, I stopped short of actually refactoring features, which I believe is in queue to be tackled in the not-too-distant future. For that reason, I did the minimal I deemed necessary to make zoolander useful for the features pattern. This is a www counterpart PR for this task to handle the above markup change. 