### PR TITLE
RSWEB-8009 [www] Infinity Numbers not displayed when the website is viewed on mobile

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -207,6 +207,7 @@
 
 .navbar-phoneicon {
   float: right;
+  font-size: 0;
 
   &::after {
     content: '\f10b';


### PR DESCRIPTION
This PR sets the `font-size` to "0" for `.navbar-phoneicon` to hide inner text used by Infinity call tracking "autodiscovery". The phone number text has to be put in the element given class `.navbar-phoneicon` for autodiscovery to work but on mobile only the icon should be visible.