### PR TITLE
RSWEB-8078: update homepage to use quadrant.jpg instead of quadrant.png

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/homepage.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/homepage.scss
@@ -141,7 +141,7 @@
 //quadrant
 
 .quadrant {
-  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/quadrant.png');
+  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/home/quadrant.jpg');
   background-position: 23% bottom;
   background-repeat: no-repeat;
   background-size: 35%;


### PR DESCRIPTION
I've optimized both the png and jpg on the cdn but this should help a bunch.

<img width="1068" alt="screen shot 2016-12-15 at 12 32 26 pm" src="https://cloud.githubusercontent.com/assets/799053/21237165/70b8ad60-c2c3-11e6-906a-a4ad4e47c31d.png">

