### PR TITLE
RSWEB-8083: max height for logo

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/stories.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/stories.scss
@@ -128,6 +128,7 @@
 }
 
 .storyOverview-logo {
+  max-height: 50%;
   max-width: 50%;
 }
 


### PR DESCRIPTION
Sets a max-height for the logos on the customer stories page