### PR TITLE
feat(npm): add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,11 @@
     "request": "^2.72.0",
     "shortid": "^2.2.6",
     "walk": "^2.3.9"
-  }
+  },
+  "files": [
+    "dist",
+    "scripts",
+    "styleguide",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
This PR defines the files that should be preserved in within `node_modules/zoolander` when Zoolander is installed with NPM. The `dist` directory is ignored by default so installing it via NPM skips that directory.