### PR TITLE
RSWEB-8026: refactor lead classses

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/lead.scss
+++ b/styleguide/_themes/derek/scss/patterns/lead.scss
@@ -1,11 +1,12 @@
-.lead,
-.lead-text {
-  font-family: $copy;
-  font-weight: $font-weight-regular;
-  text-align: center;
+.lead-bodyWrapper {
+  margin-bottom: 14px;
 }
 
-.lead-title {
+.lead-header {
   margin-top: 0;
+}
+
+.lead-wrapper {
+  font-family: $copy;
   text-align: center;
 }

--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -17,8 +17,7 @@
   margin-bottom: 1em;
 
   .lead,
-  .lead-title,
-  .lead-text {
+  .lead-wrapper {
     text-align: left;
   }
 

--- a/styleguide/_themes/global/scss/buttons.scss
+++ b/styleguide/_themes/global/scss/buttons.scss
@@ -56,6 +56,8 @@
 
   &.lead {
     @include button-lead;
+    font-family: $copy;
+    font-weight: $font-weight-regular;
   }
 
   &.learning {

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -47,7 +47,6 @@ p > a {
 h1 {
   @include heading;
   font-size: 2.25em;
-  text-align: center;
 }
 
 h2 {

--- a/styleguide/derek/_partials/solutions/lead.ejs
+++ b/styleguide/derek/_partials/solutions/lead.ejs
@@ -1,4 +1,13 @@
 <!-- Lead pattern -->
-<h1 class="lead-title">Title goes here</h1>
-<p class="lead lead-text">Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do. T-bone meatloaf chuck prosciutto biltong. Eu jowl pariatur id, ut pork belly aliquip ipsum shoulder swine est. In dolor qui pastrami, proident velit laborum prosciutto shoulder. Cow in cillum, dolor kielbasa ut occaecat aute irure.</p>
-
+<!--
+.lead class naming not used in alignment with typical pattern structure
+instead here .lead-wrapper is used to avoid having to override bootstrap base class
+ -->
+<div class="lead-wrapper">
+  <div class="lead-headerWrapper">
+    <h1 class="lead-header">Title goes here</h1>
+  </div>
+  <div class="lead-bodyWrapper">
+    <p>Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do. T-bone meatloaf chuck prosciutto biltong. Eu jowl pariatur id, ut pork belly aliquip ipsum shoulder swine est. In dolor qui pastrami, proident velit laborum prosciutto shoulder. Cow in cillum, dolor kielbasa ut occaecat aute irure.</p>
+  </div>
+</div>


### PR DESCRIPTION
Refactors lead pattern.

- removes `.lead` class and uses `.lead-wrapper` so that there is no need to overwrite bootstrap class 
- structure is in alignment with CTA refactor and uses maintainable
- does not alter subnav elements that still use original `.lead` class

http://localhost:9000/derek/solutions/solutions-usage
http://localhost:9000/derek/solutions/subpanels