### PR TITLE
RSWEB 8252 Bullet Documentation

### DIFF
--- a/styleguide/derek/_partials/cards/list.ejs
+++ b/styleguide/derek/_partials/cards/list.ejs
@@ -1,5 +1,5 @@
 <!-- Default description to allow for partial override to demonstrate really long text and equal height -->
-<% if(!list_classes) { var list_classes = "checks teal"; } %>
+<% if(!list_classes) { var list_classes = "discs"; } %>
 <% if(!items) { var items = ["Live, US-based support team", "Remotely log in and troubleshoot Virtual Machines, OS and Apps", "Dedicated account team", "15-Minute Response Time SLA to monitoring notifications"]; } %>
 
 <!-- Features List Pattern -->

--- a/styleguide/derek/_partials/typography/lists.ejs
+++ b/styleguide/derek/_partials/typography/lists.ejs
@@ -4,7 +4,7 @@
     <%- partial("../cards/list.ejs") %>
   </div>
   <div class="col-md-4">
-    <%- partial("../cards/list.ejs", {list_classes: "checks green"}) %>
+    <%- partial("../cards/list.ejs", {list_classes: "discs"}) %>
   </div>
   <div class="col-md-4">
     <%- partial("../cards/list.ejs", {items: ["Live, US-based support team", "Remotely log in and troubleshoot Virtual Machines, OS and Apps", "Dedicated account team", "15-Minute Response Time SLA to monitoring notifications", "Live, US-based support team", "Live, US-based support team"]}) %>

--- a/styleguide/derek/assets/typography.jade
+++ b/styleguide/derek/assets/typography.jade
@@ -60,7 +60,7 @@
   .row.half-padding-full
     .col-md-12
       h4.red Lists
-      p There is a pattern for a list content type available. When using the pattern or inputting a list elsewhere there are options for styling. The default is discs and in order to have the correct alignment you'll need to add <code> <ul  class="discs"> </code> but you can use <code> <ul class="checks"> </code> for check marks and these can have color added with either <code> <ul class="checks green"> or <ul class="checks teal"> </code> You can also use <code> <ul class="times"> </code> to get the x's
+      p There is a pattern for a list content type available. When using the pattern or inputting a list elsewhere there are options for styling. The default is discs and in order to have the correct alignment you'll need to add <code> <ul  class="discs"> </code> There is an option for checks and x's but those should only be used in tables. Example: <code> <ul class="checks green"> </code> for check marks and <code> <ul class="times"> </code> to get the x's
       include ../_partials/typography/lists.ejs
 
   hr

--- a/styleguide/derek/layouts/lists.ejs
+++ b/styleguide/derek/layouts/lists.ejs
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row row-eq-height">
       <div class="col-md-4 panel-flex">
-        <%- partial("../_partials/cards/list", {list_classes: "checks teal"}) %>
+        <%- partial("../_partials/cards/list", {list_classes: "discs"}) %>
       </div>
       <div class="col-md-4 panel-flex">
         <%- partial("../_partials/cards/list", {list_classes: "checks green"}) %>

--- a/styleguide/derek/solutions/solutions-usage.ejs
+++ b/styleguide/derek/solutions/solutions-usage.ejs
@@ -215,13 +215,14 @@
       <ul class="times">
         <li>Exceed character limit</li>
         <li>Try not to use more than 4 cards whenever possible</li>
+        <li>Use colored check marks in lists</li>
       </ul>
     </div>
   </div>
   <h5 class="red">Example:</h5>
 </div>
 <div class="bg-light-gray half-padding">
-  <%- partial('layouts/features.ejs') %>
+  <%- partial('../layouts/features.ejs') %>
 </div>
 <div class="bg-light-gray">
   <div class="container half-padding">


### PR DESCRIPTION
Adding documentation for bullets and removing old examples from zoolander.
Visible here: 
http://localhost:9000/derek/solutions/solutions-usage
and
http://localhost:9000/derek/assets/typography

