### PR TITLE
RSWEB-8405: Move CSS from general content type into repo

### DIFF
--- a/styleguide/_themes/derek/scss/snowflakes/homepage.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/homepage.scss
@@ -18,6 +18,7 @@
 .hostingOptions-product {
   @include make-xs-column(6);
   color: $gray-base;
+  margin-bottom: 25px;
   text-align: center;
   text-decoration: none;
 
@@ -232,6 +233,10 @@
   //equal height columns remove in small
   .hostingOptions-productRow {
     display: block;
+  }
+
+  .hostingOptions-product {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
This PR pulls in a few minor style updates that are currently set inside `<style></style>` tags in a general content type. 

@amberRrucker can you please confirm this is the correct solution to this problem, instead of just removing the on page style altogether? 