### PR TITLE
RSWEB-8096: Fixes gutter related issues.

### DIFF
--- a/styleguide/_themes/derek/scss/components/subnav.scss
+++ b/styleguide/_themes/derek/scss/components/subnav.scss
@@ -4,7 +4,8 @@
 }
 
 .subnav-container {
-  @include make-container;
+  margin: 0 auto;
+  max-width: $screen-md-max;
   padding: 0;
 }
 
@@ -55,8 +56,8 @@
   border-bottom: solid transparent 4px;
   float: left;
   height: 50px;
-  margin: 10px 0 0;
-  padding: 7px 10px 6px;
+  margin-top: 10px;
+  padding: 7px ($grid-gutter-width / 4) 6px;
 
   &:hover {
     background-color: transparent;
@@ -107,7 +108,7 @@
 
 .subnav-noHover {
   float: right;
-  margin: 5px 0;
+  margin: 5px $grid-gutter-width 5px 0;
   padding: 8px 0;
 
   &:hover {
@@ -118,12 +119,7 @@
 @media only screen and (max-width: $screen-md-max) {
   .subnav-item {
     font-size: .9em;
-    margin: 10px 0 0;
     padding: 7px 10px 6px;
-  }
-
-  .subnav-noHover {
-    margin: 5px 0;
   }
 
   .subnav-container {
@@ -140,7 +136,7 @@
     border-bottom: 0;
     border-left: 2px solid transparent;
     height: auto;
-    margin: 0;
+    margin-top: 0;
     padding: 10px 8px;
     width: $full-width;
 
@@ -159,11 +155,16 @@
   }
 
   .subnav-noHover {
-    margin: 0;
     padding-left: 8px;
 
     &:hover {
       border-left: solid transparent 2px;
     }
+  }
+}
+
+@media only screen and (min-width: $screen-lg-min + $grid-gutter-width * 2) {
+  .subnav-noHover {
+    margin-right: 0;
   }
 }

--- a/styleguide/_themes/global/scss/modifiers.scss
+++ b/styleguide/_themes/global/scss/modifiers.scss
@@ -147,3 +147,17 @@ img { max-width: 100%; }
 .white {
   color: $white;
 }
+
+@media only screen and (min-width: $screen-lg-min) {
+  .half-padding,
+  .standard-padding {
+    padding-left: $grid-gutter-width;
+    padding-right: $grid-gutter-width;
+  }
+
+  .half-padding-full,
+  .standard-padding-full {
+    padding-left: $grid-gutter-width / 2;
+    padding-right: $grid-gutter-width / 2;
+  }
+}


### PR DESCRIPTION
This PR fixes a few gutter related issues.  

1. d54c7941ae27c7cc1fd40764fedfe145637868e5 - Gets rid of containers around subnav and specifies a better gutter width for subnav items
2. 3a383650582df5bbd81de168ca0ab3908c92bf37 - Adjusts padding on half-padding/standard-padding when viewing in 1280px+
3. 068b4854d45d1bd6d22bec68044fd7f2796ce46d - Sets a margin-right of `$grid-gutter-width` unless you're in 1280px + gutter width*2. 

Can be tested in zoolander here: http://localhost:9000/derek/incubation/office365
One thing to keep in mind (and part of the reason for item 3 above, is to give room for the chat slider button.)