### PR TITLE
RSWEB-8507: fix for subnav mobile being cut off on left side

### DIFF
--- a/styleguide/_themes/derek/scss/components/subnav.scss
+++ b/styleguide/_themes/derek/scss/components/subnav.scss
@@ -155,6 +155,7 @@
   }
 
   .subnav-noHover {
+    margin: 5px auto;
     padding-left: 8px;
 
     &:hover {


### PR DESCRIPTION
Fixes the issue when viewing in the mobile viewport where the CTA in the subnav is off the screen on the left side.

http://localhost:9000/derek/incubation/office365