### PR TITLE
rsweb-8494-switch-brand-secondary

### DIFF
--- a/styleguide/_themes/derek/scss/components/subnav.scss
+++ b/styleguide/_themes/derek/scss/components/subnav.scss
@@ -1,6 +1,6 @@
 .subnav {
   background-color: $gray-dark;
-  border-bottom: 0;
+  border: 0;
   border-radius: 0;
 }
 
@@ -11,8 +11,30 @@
 }
 
 .subnav-links {
-  list-style-type: none;
+  list-style: none;
+  margin: 0;
   padding: 0;
+}
+
+.subnav-link {
+  border-bottom: 3px solid transparent;
+  color: $white;
+  display: block;
+  font-size: $navigation-font-size;
+  font-weight: $font-weight-black;
+  line-height: 2.1rem;
+  padding: 20px 13px 17px;
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:visited,
+  &:active {
+    background-color: transparent;
+    border-bottom: 3px solid $brand-primary;
+    color: $white;
+    text-decoration: none;
+  }
 }
 
 .subnav-header {
@@ -38,7 +60,7 @@
 .subnav-pageTitleContainer {
   @include make-xs-column(11);
   display: none;
-  margin-top: 5px;
+  margin-top: 0;
 }
 
 .subnav-pageTitle {
@@ -54,44 +76,12 @@
 }
 
 .subnav-item {
-  border-bottom: solid transparent 4px;
   float: left;
-  height: 50px;
-  margin-top: 10px;
-  padding: 7px ($grid-gutter-width / 4) 6px;
-
-  &:hover {
-    background-color: transparent;
-    border-bottom: solid $teal-dark 4px;
-  }
-
-  &:focus {
-    background-color: transparent;
-  }
-}
-
-.subnav-item-active {
-  background-color: transparent;
-  border-bottom: solid $teal-dark 4px;
-}
-
-.subnav-link {
-  color: $white;
-  font-size: .95em;
-  font-weight: $font-weight-regular;
-  padding-bottom: 16px;
-  padding-top: 12px;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    background-color: transparent;
-    color: $white;
-    text-decoration: none;
-  }
 }
 
 .subnav-link-active {
+  background-color: transparent;
+  border-bottom: solid $brand-primary 3px;
   color: $white;
   text-decoration: none;
 }
@@ -99,6 +89,9 @@
 .subnav-leadBtn {
   @include button;
   @include button-lead;
+  font-size: $navigation-font-size;
+  font-weight: 600;
+  line-height: 2.1rem;
   padding: 8px 10px;
 
   &:focus {
@@ -109,7 +102,7 @@
 
 .subnav-noHover {
   float: right;
-  margin-top: 1px;
+  margin-top: 11px;
 
   &:hover {
     border-bottom: solid transparent 4px;
@@ -118,8 +111,9 @@
 
 @media only screen and (max-width: $screen-md-max) {
   .subnav-item {
+    border-bottom: 0;
     font-size: .9em;
-    padding: 7px 10px 6px;
+    padding: 0 5px;
   }
 
   .subnav-container {
@@ -132,17 +126,24 @@
     padding-top: 5px;
   }
 
+  .subnav-link {
+    border-bottom: 0;
+
+    &:hover {
+      border-bottom: 0;
+    }
+  }
+
   .subnav-item {
     border-bottom: 0;
     border-left: 2px solid transparent;
     height: auto;
     margin-top: 0;
-    padding: 10px 8px;
     width: $full-width;
 
     &:hover {
       border-bottom: 0;
-      border-left: 2px solid $teal-dark;
+      border-left: 2px solid $brand-primary;
     }
   }
 

--- a/styleguide/_themes/derek/scss/patterns/announcements.scss
+++ b/styleguide/_themes/derek/scss/patterns/announcements.scss
@@ -61,7 +61,7 @@
 
 //New Product announcements
 .announcement-newProduct {
-  border-left: 8px solid $brand-secondary;
+  border-left: 8px solid $brand-info;
 }
 
 //Promotion announcements

--- a/styleguide/_themes/derek/scss/patterns/panels.scss
+++ b/styleguide/_themes/derek/scss/patterns/panels.scss
@@ -75,7 +75,7 @@
 }
 
 .subpanelWell-medium-teal {
-  background: $brand-secondary;
+  background: $teal-dark;
 }
 
 .subpanelWell-crumpled-paper {

--- a/styleguide/_themes/derek/scss/snowflakes/o365.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/o365.scss
@@ -164,26 +164,6 @@ a {
     padding: 20px 0;
     text-align: center;
   }
-
-  .triangle {
-    border-left: 110px solid transparent;
-    border-top: 90px solid $brand-secondary;
-    position: absolute;
-    right: -1px;
-    top: -1px;
-  }
-
-  .triangle-text {
-    position: absolute;
-    right: 8px;
-    top: 0;
-
-    h4 {
-      color: $white;
-      line-height: 1em;
-      text-align: center;
-    }
-  }
 }
 
 .pricing-header-row {

--- a/styleguide/_themes/derek/scss/snowflakes/swatches.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/swatches.scss
@@ -5,7 +5,7 @@
   &.signup-green { background-color: $brand-success; }
   &.magento-orange { background-color: $orange; }
   &.purple { background-color: $purple; }
-  &.mustard { background-color: $mustard; }
+  &.teal { background-color: $teal-medium; }
 
   //grays
   &.gray-light { background-color: $gray-lighter; }
@@ -37,8 +37,8 @@
   top: 0;
   width: 40px;
   &.signup-green { background-color: lighten($brand-success, 5%); }
-  &.mustard { background-color: lighten($mustard, 5%); }
-  &.brand-secondary { background-color: $teal-dark; }
+  &.teal { background-color: lighten($teal-medium, 5%); }
+  &.brand-secondary { background-color: lighten($brand-secondary, 5%); }
 }
 
 .swatch-color-darker {
@@ -47,7 +47,7 @@
   right: 15px;
   top: 40px;
   width: 40px;
-  &.mustard { background-color: darken($mustard, 10%); }
+  &.teal { background-color: $teal-dark; }
 }
 
 .swatch-footer {

--- a/styleguide/_themes/global/scss/bootstrap_variables.scss
+++ b/styleguide/_themes/global/scss/bootstrap_variables.scss
@@ -22,13 +22,14 @@ $gray-lightest:          #efefef !default;
 //added for ordering issues
 $rackspace-red:     #c40022;
 $signup-green:      #5aaa28;
-$teal-medium:       #0dcfd9;
+$mustard:           #f6b100;
+$teal-dark:         #00b4c3;
 $orange:            #f63;
 
 $brand-primary:         $rackspace-red  !default;
-$brand-secondary:       $teal-medium    !default;
+$brand-secondary:       $mustard        !default;
 $brand-success:         $signup-green   !default;
-$brand-info:            #c4c8ce         !default;
+$brand-info:            $teal-dark      !default;
 $brand-warning:         $orange         !default;
 $brand-danger:          $rackspace-red  !default;
 

--- a/styleguide/_themes/global/scss/buttons.scss
+++ b/styleguide/_themes/global/scss/buttons.scss
@@ -33,12 +33,12 @@
 
 @mixin button-learning {
   background-color: $white;
-  border: $brand-secondary 3px solid;
+  border: $teal-dark 3px solid;
   color: $gray-darkest;
   padding: 8px 50px;
 
   &:hover {
-    background-color: $brand-secondary;
+    background-color: $teal-dark;
     color: $white;
   }
 }

--- a/styleguide/_themes/global/scss/forms.scss
+++ b/styleguide/_themes/global/scss/forms.scss
@@ -175,7 +175,7 @@ table {
   box-shadow: none;
 
   &:focus {
-    border-color: $brand-secondary;
+    border-color: $brand-info;
     box-shadow: none;
     outline: 0;
   }

--- a/styleguide/_themes/global/scss/modifiers.scss
+++ b/styleguide/_themes/global/scss/modifiers.scss
@@ -133,6 +133,10 @@ hr {
 }
 
 .bg-medium-teal {
+  background: $teal-dark;
+}
+
+.bg-mustard {
   background: $brand-secondary;
 }
 

--- a/styleguide/_themes/global/scss/swatch.scss
+++ b/styleguide/_themes/global/scss/swatch.scss
@@ -4,17 +4,17 @@ $images: 'https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.
 //primary colors
 $rackspace-red:     #c40022;
 $signup-green:      #5aaa28;
-$teal-medium:       #0dcfd9;
-$teal-dark:         #00b4c3;
+$mustard:           #f6b100;
 
 //accent colors
 $orange:            #f63;
 $purple:            #639;
-$mustard:           #f6b100;
+$teal-medium:       #0dcfd9;
+$teal-dark:         #00b4c3;
+$blue-login:        #0c808c;
 $blue-steel:        #0d1b2a;
 //depreciating blue-gray. Don't use for additional elements.
 $blue-gray:         #2e3238;
-$blue-login:        #0c808c;
 
 //Grays already defined in bootstrap variables - here as reference
 $white:             #fff    !default;
@@ -29,7 +29,7 @@ $gray-lightest:     #efefef !default;
 
 //our primaries defined in bootstrap variables - here as reference
 $brand-primary:     $rackspace-red !default;
-$brand-secondary:   $teal-medium   !default;
+$brand-secondary:   $mustard       !default;
 $brand-success:     $signup-green  !default;
 $brand-warning:     $orange        !default;
 $brand-danger:      $rackspace-red !default;

--- a/styleguide/_themes/global/scss/tables.scss
+++ b/styleguide/_themes/global/scss/tables.scss
@@ -23,7 +23,7 @@ $table-padding: 20px 5px;
 
 .productTable-feature {
   @include subhead;
-  color: $teal-dark;
+  color: $gray-dark;
   padding: $table-padding;
   text-align: center;
   width: 20%;

--- a/styleguide/derek/assets/swatches.ejs
+++ b/styleguide/derek/assets/swatches.ejs
@@ -54,7 +54,7 @@
           </div>
           <div class="swatch-footer">
             <h6>$brand-secondary</h6>
-            <h6>#0DCFD9</h6>
+            <h6>#f6b100</h6>
           </div>
         </div>
         <div class="col-sm-3 col-xs-6">
@@ -86,8 +86,8 @@
             </div>
           </div>
           <div class="swatch-footer">
-            <h6>$mustard</h6>
-            <h6>#f6b100</h6>
+            <h6>$teal-medium</h6>
+            <h6>#0DCFD9</h6>
           </div>
         </div>
         <div class="col-sm-3 col-xs-6">

--- a/styleguide/derek/incubation/office365.ejs
+++ b/styleguide/derek/incubation/office365.ejs
@@ -100,8 +100,6 @@
                            <hr/>
                            <p class="white"><strong>Email + Office 2016</strong><br/>
                             All the features in our Business Essentials and Business plans</p>
-                            <div class="triangle"></div>
-                            <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
                       </td>
                       <td id="enterprise" class="col-md-2">
                         <br/>
@@ -937,8 +935,6 @@
                    <hr class="white"/>
                    <p class="white"><strong>Email + Office 2016</strong><br/>
                     All the features in our Business Essentials and Business plans</p>
-                    <div class="triangle"></div>
-                    <div class="triangle-text"><h4>Save<br/>17<sup>%</sup></h4></div>
                 </div>
                 <div class="panel-body pricing hidden-md hidden-lg">
                   <div class="row">


### PR DESCRIPTION
RSWEB-8494

This one took a bit of a weird turn. Instead of doing all of these individually I switched brand secondary and it effects these things:
corner-pocket text
subnav hover
learning button border
o365 discount triangle (isnt even used anymore. dumped the code for it.)
all a tags will switch to red and hover red(darken) to avoid them switching to mustard hover

Stakeholders need to see this on a dev branch pre deploy.