### PR TITLE
rsweb-8495-link-style

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/announcements.scss
+++ b/styleguide/_themes/derek/scss/patterns/announcements.scss
@@ -19,12 +19,13 @@
 }
 
 .announcement-link {
-  line-height: inherit;
+  @include standard-link;
+  color: $gray-dark;
   text-decoration: none;
 
   &:hover,
   &:focus {
-    color: $blue-gray;
+    color: $rackspace-red;
     text-decoration: none;
   }
 }
@@ -39,7 +40,7 @@
 
   &:hover {
     background-color: $gray-lightest;
-    color: $blue-gray;
+    color: $gray-dark;
   }
 }
 

--- a/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/businessResource.scss
@@ -26,8 +26,7 @@
     }
 
     a {
-      color: $white;
-      text-decoration: none;
+      @include standard-link;
     }
 
     img {

--- a/styleguide/_themes/derek/scss/patterns/cards/ias.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/ias.scss
@@ -46,6 +46,10 @@
   .rsweb {
     font-size: 7rem;
   }
+
+  a {
+    @include standard-link;
+  }
 }
 
 .iasWidget-bottom {

--- a/styleguide/_themes/derek/scss/patterns/cards/keyOffers.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/keyOffers.scss
@@ -21,6 +21,10 @@
   position: relative;
   text-decoration: none;
   width: 100%;
+
+  a {
+    @include standard-link;
+  }
 }
 
 .keyoffersWidget-body {

--- a/styleguide/_themes/derek/scss/patterns/cards/modules.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/modules.scss
@@ -80,6 +80,14 @@
   margin: 10px;
 }
 
+.node-text > a {
+  @include standard-link;
+}
+
+.node-general > a {
+  @include standard-link;
+}
+
 .calculator {
   h3 {
     font-size: 16px;

--- a/styleguide/_themes/derek/scss/patterns/cards/productFeatures.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/productFeatures.scss
@@ -15,13 +15,7 @@
 
 .feature-bodyWrapper {
   a {
-    font-size: 1.5rem;
-    font-weight: $font-weight-black;
-    text-decoration: underline;
-
-    &:hover {
-      color: $brand-primary;
-    }
+    @include standard-link;
   }
 }
 

--- a/styleguide/_themes/derek/scss/patterns/lead.scss
+++ b/styleguide/_themes/derek/scss/patterns/lead.scss
@@ -2,6 +2,10 @@
   margin-bottom: 14px;
 }
 
+.lead-bodyWrapper > a {
+  @include standard-link;
+}
+
 .lead-header {
   margin-top: 0;
 }
@@ -9,4 +13,8 @@
 .lead-wrapper {
   font-family: $copy;
   text-align: center;
+}
+
+.lead-link {
+  @include standard-link;
 }

--- a/styleguide/_themes/derek/scss/snowflakes/events.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/events.scss
@@ -145,6 +145,7 @@
 .eventsOverview-weekEvent-learnMore {
   @include button;
   @include button-learning;
+  color: $gray-darkest;
   margin-bottom: 1rem;
   width: auto;
 }

--- a/styleguide/_themes/derek/scss/snowflakes/o365.scss
+++ b/styleguide/_themes/derek/scss/snowflakes/o365.scss
@@ -41,14 +41,6 @@ a {
 .pricing {
   background-color: $white;
 
-  a {
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
   h3 {
     &.teal {
       color: $teal-dark;

--- a/styleguide/_themes/global/scss/buttons.scss
+++ b/styleguide/_themes/global/scss/buttons.scss
@@ -1,4 +1,5 @@
 @mixin button {
+  background-color: transparent;
   border: 0;
   border-radius: 0;
   box-shadow: none;

--- a/styleguide/_themes/global/scss/cta.scss
+++ b/styleguide/_themes/global/scss/cta.scss
@@ -43,6 +43,7 @@
   }
 
   a {
-    text-decoration: underline;
+    @include standard-link;
+    color: $gray-darkest;
   }
 }

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -34,14 +34,19 @@ p {
   margin: 0 0 1em;
 }
 
-p > a {
+@mixin standard-link {
+  color: $rackspace-red;
   cursor: pointer;
   font-weight: $font-weight-regular;
   text-decoration: underline;
 
   &:hover {
-    color: $brand-secondary;
+    color: darken($rackspace-red, 10%);
   }
+}
+
+p > a {
+  @include standard-link;
 }
 
 h1 {
@@ -164,11 +169,11 @@ i {
 }
 
 .read-more {
-  margin-top: 20px;
+  color: $brand-primary;
+  text-decoration: underline;
 
-  a {
-    color: $white;
-    text-decoration: none;
+  &:hover {
+    color: darken($brand-primary, 5%);
   }
 }
 

--- a/styleguide/derek/_partials/solutions/cta-bottom.ejs
+++ b/styleguide/derek/_partials/solutions/cta-bottom.ejs
@@ -11,6 +11,11 @@
         <a class="cta-button">Talk to a Specialist</a>
       </div>
     </div>
+    <div class="cta-row">
+      <div class="cta-subheadWrapper">
+        <p class="cta-subhead">Call <a href="javascript:void(0)">1-855-715-7307</a> to start saving</p>
+      </div>
+    </div>
   </div>
   <!-- end CTA -->
 </div>

--- a/styleguide/derek/_partials/solutions/lead.ejs
+++ b/styleguide/derek/_partials/solutions/lead.ejs
@@ -9,5 +9,6 @@ instead here .lead-wrapper is used to avoid having to override bootstrap base cl
   </div>
   <div class="lead-bodyWrapper">
     <p>Bacon ipsum dolor amet minim tri-tip pork chop fatback pork loin, salami shoulder pastrami cow id tongue aliquip nostrud. Nisi in magna, flank picanha eiusmod lorem jowl swine frankfurter do. T-bone meatloaf chuck prosciutto biltong. Eu jowl pariatur id, ut pork belly aliquip ipsum shoulder swine est. In dolor qui pastrami, proident velit laborum prosciutto shoulder. Cow in cillum, dolor kielbasa ut occaecat aute irure.</p>
+    <a href="#" class="lead-link"> A link within a lead</a>
   </div>
 </div>

--- a/styleguide/derek/_partials/typography/body-copy.ejs
+++ b/styleguide/derek/_partials/typography/body-copy.ejs
@@ -1,5 +1,7 @@
-<div class="container half-padding">
-  <div class="row half-padding-top">
-    <p></p>
+<div class="container">
+  <div class="row half-padding">
+    <p>Etsy raclette vape, chillwave iPhone skateboard YOLO williamsburg pork belly ethical normcore viral. Quinoa paleo fingerstache, food truck helvetica fashion axe gochujang normcore. Post-ironic mlkshk lyft, fingerstache tumeric fixie hella whatever photo booth swag kombucha franzen affogato. Cray artisan portland kickstarter, four loko af biodiesel heirloom thundercats.</p>
+    <p>Fam coloring book snackwave, asymmetrical heirloom vexillologist pinterest. Shoreditch <a href="#">pork belly</a> ennui fanny pack vegan fixie, messenger bag lyft wayfarers direct trade semiotics succulents waistcoat chartreuse flexitarian. Raw denim cred tousled, actually next level four loko venmo vice squid meh man braid letterpress cold-pressed.</p>
+    <a href="#" class="read-more">Lomo wayfarers before they sold out</a>
   </div>
 </div>

--- a/styleguide/derek/assets/typography.jade
+++ b/styleguide/derek/assets/typography.jade
@@ -28,8 +28,11 @@
 
   .row.half-padding-full
     .col-md-12
-      h2.red NEED TO ADD
-      p.red body copy
+      h2.red Body Copy
+      p Body copy blocks should be left aligned by default. It should only center if the pattern centers it automatically.
+      p Do not exceed more than two links per paragraph and links should not be more than four words long. Links outside of the paragraph tag but within the text block should be text links with the class .read-more, never buttons.
+      h4 Example:
+      include ../_partials/typography/body-copy.ejs
 
   hr
 


### PR DESCRIPTION
RSWEB-8495
Adjusting links to be red and underlined in copy across the site.
Should darken on hover.