### PR TITLE
RSWEB-8623: change out logo image to rm bg color

### DIFF
--- a/styleguide/_themes/derek/scss/globalElements/mainnav.scss
+++ b/styleguide/_themes/derek/scss/globalElements/mainnav.scss
@@ -123,12 +123,14 @@
 }
 
 .navbar-brand {
-  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/slimLogo.svg');
-  background-position: left top;
+  background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/logos/rs-logo.svg');
+  background-position: left 50%;
   background-repeat: no-repeat;
+  background-size: 100% 79%;
   height: 35px;
   margin: 5px 10px;
   position: relative;
+  transition-duration: .3s;
   width: 150px;
 }
 


### PR DESCRIPTION
Changes out Rackspace logo in eyebrow to remove blue-gray bg from svg. 
Resizes new svg and adds slight transition when going from desktop to mobile.

http://localhost:9000/derek/templates/section-overview