### PR TITLE
rsweb-8624-submenu-cta

### DIFF
--- a/styleguide/_themes/derek/scss/components/subnav.scss
+++ b/styleguide/_themes/derek/scss/components/subnav.scss
@@ -1,5 +1,6 @@
 .subnav {
   background-color: $gray-dark;
+  border-bottom: 0;
   border-radius: 0;
 }
 
@@ -108,8 +109,7 @@
 
 .subnav-noHover {
   float: right;
-  margin: 5px $grid-gutter-width 5px 0;
-  padding: 8px 0;
+  margin-top: 1px;
 
   &:hover {
     border-bottom: solid transparent 4px;


### PR DESCRIPTION
RSWEB-8624
Adjusting the subnav cta to have proper alignment
Also removed a transparent bottom border on the subnav that was causing a 1px gap below hover state on subnav menu items.

Viewable here:
http://localhost:9000/derek/incubation/office365