### PR TITLE
RSWEB-8591: Add portfolio pattern

### DIFF
--- a/styleguide/_themes/derek/scss/_main.scss
+++ b/styleguide/_themes/derek/scss/_main.scss
@@ -18,6 +18,7 @@
 @import 'patterns/quote';
 @import 'patterns/videoEmbed';
 @import 'patterns/panels';
+@import 'patterns/portfolio';
 @import 'patterns/cards/modules';
 @import 'patterns/cards/keyOffers';
 @import 'patterns/cards/businessResource';

--- a/styleguide/_themes/derek/scss/components/tabs.scss
+++ b/styleguide/_themes/derek/scss/components/tabs.scss
@@ -107,6 +107,14 @@
   }
 }
 
+.rsTabs-contentBody {
+  margin-bottom: 25px;
+}
+
+.rsTabsHorizontal-contentHeader {
+  text-align: center;
+}
+
 @media (min-width: $screen-sm-min) {
   // Horizontal Tabs
   .rsTabsHorizontal {
@@ -157,6 +165,10 @@
     padding-left: 25px;
     padding-right: 0;
     width: 85%;
+  }
+
+  .rsTabsVertical-contentHeader {
+    margin-top: 0;
   }
 
   .rsTabVertical-tab {

--- a/styleguide/_themes/derek/scss/patterns/portfolio.scss
+++ b/styleguide/_themes/derek/scss/patterns/portfolio.scss
@@ -1,0 +1,23 @@
+.portfolio-wrapper {
+  .keyoffersWidget {
+    background: $gray-lightest;
+  }
+
+  .keyoffersWidget-hover {
+    &:hover {
+      background: $gray-lighter;
+    }
+  }
+}
+
+.portfolio-row {
+  @include make-row;
+}
+
+@media (min-width: $screen-sm-min) {
+  .portfolio-row {
+    @include flex-box;
+    margin-bottom: 10px;
+    margin-right: 0;
+  }
+}

--- a/styleguide/derek/_partials/solutions/portfolio.ejs
+++ b/styleguide/derek/_partials/solutions/portfolio.ejs
@@ -1,0 +1,60 @@
+<%
+  if(!title) { var title = "Portfolio Tab Title"; }
+  if(!rowCt) { var rowCt = 2; }
+%>
+
+<h2 class="rsTabs-contentHeader rsTabsVertical-contentHeader"><%- title %></h2>
+<div class="rsTabs-contentBody">
+  <p>Maecenas placerat odio libero, porttitor rhoncus enim pharetra eu. Praesent in porttitor nulla. Nunc consequat metus sit amet magna vulputate suscipit. Proin justo libero, fermentum sit amet ullamcorper non, sagittis ut eros. Etiam vestibulum, mi quis posuere laoreet, purus nisi maximus massa, non varius felis arcu vel nulla. Nam sollicitudin suscipit augue, eu hendrerit purus vehicula ut. Curabitur efficitur consectetur interdum.</p>
+</div>
+
+<div class="portfolio-wrapper">
+  <div class="portfolio-row">
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel panel-flex">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer.ejs') %>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel panel-flex">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer-no-hover.ejs') %>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel panel-flex">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer.ejs') %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% if (rowCt > 1) { %>
+  <div class="portfolio-row">
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel panel-flex">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer-no-hover.ejs') %>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer.ejs') %>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-4 panel-flex">
+      <div class="subpanel panel-flex">
+        <div class="subpanel-inner panel-flex">
+          <%- partial('../cards/key-offer-no-hover.ejs') %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% } %>
+</div>

--- a/styleguide/derek/_partials/solutions/tabs-vertical.ejs
+++ b/styleguide/derek/_partials/solutions/tabs-vertical.ejs
@@ -1,65 +1,22 @@
 <div class="rsTabs-container rsTabsVertical-container">
   <ul class="nav nav-tabs rsTabs rsTabsVertical">
-    <li class="rsTab-tab rsTabVertical-tab active"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-1" data-toggle="tab">Tab 1</a></li>
-    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-2" data-toggle="tab">Tab 2</a></li>
-    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-3" data-toggle="tab">Tab 3</a></li>
-    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-4" data-toggle="tab">Tab 4</a></li>
+    <li class="rsTab-tab rsTabVertical-tab active"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-1" data-toggle="tab">One Row</a></li>
+    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-2" data-toggle="tab">Two Rows</a></li>
+    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-3" data-toggle="tab">One Row Again</a></li>
+    <li class="rsTab-tab rsTabVertical-tab"><a class="rsTab-link rsTabVertical-link" href="#tab-vertical-4" data-toggle="tab">Two Rows Again</a></li>
   </ul>
   <div id="myTabContent" class="tab-content rsTabs-content rsTabsVertical-content">
       <div class="tab-pane active" id="tab-vertical-1">
-          <p>Raw denim you probably haven't...</p>
+        <%- partial('portfolio.ejs', {title: 'Single row', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="tab-vertical-2">
-          <p>Food truck fixie locavore, accus...</p>
+        <%- partial('portfolio.ejs', {title: 'Double rows'}) %>
       </div>
       <div class="tab-pane" id="tab-vertical-3">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Another single row tab', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="tab-vertical-4">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Another double row tab'}) %>
       </div>
   </div>
 </div>

--- a/styleguide/derek/_partials/solutions/tabs-verticalLong.ejs
+++ b/styleguide/derek/_partials/solutions/tabs-verticalLong.ejs
@@ -19,224 +19,52 @@
   </ul>
   <div id="myTabContent" class="tab-content rsTabs-content rsTabsVertical-content">
       <div class="tab-pane active" id="vertical-tab1">
-          <p>Raw denim you probably haven't...</p>
+        <%- partial('portfolio.ejs', {title: 'Tab 1', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab2">
-          <p>Food truck fixie locavore, accus...</p>
+        <%- partial('portfolio.ejs', {title: 'Tab 2', rowCt: 2}) %>
       </div>
       <div class="tab-pane" id="vertical-tab3">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 3', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab4">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 4', rowCt: 2}) %>
       </div>
-      <div class="tab-pane active" id="vertical-tab5">
-          <p>Raw denim you probably haven't...</p>
+      <div class="tab-pane" id="vertical-tab5">
+        <%- partial('portfolio.ejs', {title: 'Tab 5', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab6">
-          <p>Food truck fixie locavore, accus...</p>
+        <%- partial('portfolio.ejs', {title: 'Tab 6', rowCt: 2}) %>
       </div>
       <div class="tab-pane" id="vertical-tab7">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 7', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab8">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 8', rowCt: 2}) %>
       </div>
-      <div class="tab-pane active" id="vertical-tab9">
-          <p>Raw denim you probably haven't...</p>
+      <div class="tab-pane" id="vertical-tab9">
+        <%- partial('portfolio.ejs', {title: 'Tab 9', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab10">
-          <p>Food truck fixie locavore, accus...</p>
+        <%- partial('portfolio.ejs', {title: 'Tab 10', rowCt: 2}) %>
       </div>
       <div class="tab-pane" id="vertical-tab11">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 11', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab12">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 12', rowCt: 2}) %>
       </div>
-      <div class="tab-pane active" id="vertical-tab13">
-          <p>Raw denim you probably haven't...</p>
+      <div class="tab-pane" id="vertical-tab13">
+        <%- partial('portfolio.ejs', {title: 'Tab 13', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab14">
-          <p>Food truck fixie locavore, accus...</p>
+        <%- partial('portfolio.ejs', {title: 'Tab 13', rowCt: 2}) %>
       </div>
       <div class="tab-pane" id="vertical-tab15">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 15', rowCt: 1}) %>
       </div>
       <div class="tab-pane" id="vertical-tab16">
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Activated charcoal blog polaroid, next level four loko
-          listicle vice swag neutra authentic. Actually green juice
-          vape, +1 mlkshk woke meh before they sold out kombucha.
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
-        <p>
-          Letterpress banh mi narwhal, everyday carry craft beer
-          man braid you probably haven't heard of them. 90's iPhone
-          bushwick hella distillery, artisan tilde readymade before
-          they sold out pickled man braid swag yuccie.
-        </p>
+        <%- partial('portfolio.ejs', {title: 'Tab 16', rowCt: 2}) %>
       </div>
   </div>
 </div>

--- a/styleguide/derek/layouts/tabs.ejs
+++ b/styleguide/derek/layouts/tabs.ejs
@@ -23,7 +23,7 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12">
-      <h4>Rs tabs - Vertical</h4>
+      <h4>Product Portfolio (Vertical Tabs)</h4>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR adds the portfolio pattern into zoolander.

A few notes about this:

1. Mike asked me to not include the icon on the portfolio tabs, so it's just header/text/key offers now.
2. Since this is presently the only acceptable use of vertical tabs in the system, I replaced all existing vertical tab content with portfolio pattern content, instead of adding a new section for product portfolio. I think we covered it last time, but if I need to update any of the usage documentation around that, please let me know. 
3. Chatting with @runrog today, we opted to use gray backgrounds on all of the key offers here. The main issue with this is, without it the content would look oddly indented due to the padding on the key offer pattern. We could theoretically offset this padding with a margin, but then the hover state rests right against the tab line on the left. If CROUX decides to do something else here, that is fine, but thought I'd explain the rational behind the gray background, and also that was after chatting with Roger about it. 
4. While I don't necessarily like it, I did opt to nest `.keyoffersWidget` inside of `.portfolio-wrapper`. The reason for this, is because has a hardcoded background, and it needs to be overridden. This PR didn't seem like the place to try to globally make changes to the key offers pattern, so I opted to limit the impact here by only changing this one context. I'd recommend in the future trying to remove background colors from patterns, and allowing for style modes in the CMS handle that, but that is a task for another day. 
5. While it's never used here in zoolander, I created `.rsTabsHorizontal-contentHeader` to replace the `pattern-header center` class on the horizontal tabs. This can easily be converted and www, and allows us more easily make the shift to maintainable classes here. 