### PR TITLE
rsweb-8523-new-corner-pocket

### DIFF
--- a/styleguide/_themes/derek/scss/_main.scss
+++ b/styleguide/_themes/derek/scss/_main.scss
@@ -19,6 +19,7 @@
 @import 'patterns/videoEmbed';
 @import 'patterns/panels';
 @import 'patterns/cards/modules';
+@import 'patterns/cards/cornerPocket';
 @import 'patterns/cards/keyOffers';
 @import 'patterns/cards/businessResource';
 @import 'patterns/cards/productFeatures';

--- a/styleguide/_themes/derek/scss/patterns/cards/cornerPocket.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/cornerPocket.scss
@@ -1,0 +1,36 @@
+.cornerPocket-wrapper {
+  background-color: $gray-darkest;
+  color: $white;
+  padding: 15px;
+}
+
+.cornerPocket-borderWrapper {
+  border: 4px solid $white;
+  padding: 10px;
+}
+
+.cornerPocket-callout {
+  @include heading;
+  color: $white;
+  font-size: 3.75rem;
+  line-height: 4.5rem;
+  margin: 0;
+  text-transform: uppercase;
+  word-wrap: break-word;
+}
+
+.cornerPocket-heading {
+  @include heading;
+  color: $white;
+  font-size: 3rem;
+  font-weight: 300;
+  line-height: 4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.cornerPocket-text {
+  font-size: 1.25rem;
+  line-height: 2rem;
+  margin: 0;
+}

--- a/styleguide/derek/_partials/cards/corner-pocket.ejs
+++ b/styleguide/derek/_partials/cards/corner-pocket.ejs
@@ -1,0 +1,7 @@
+<div class="cornerPocket-wrapper">
+  <div class="cornerPocket-borderWrapper">
+  	<p class="cornerPocket-heading">Starting at</h3>
+  	<p class="cornerPocket-callout">$0.015/hr</h2>
+  	<p class="cornerPocket-text">High availability without a long-term contract</p>
+	</div>
+</div>

--- a/styleguide/derek/layouts/leadCornerPocket.ejs
+++ b/styleguide/derek/layouts/leadCornerPocket.ejs
@@ -1,0 +1,18 @@
+<div class="container half-padding-full">
+  <div class="row">
+    <div class="col-sm-9">
+      <div class="subpanel">
+        <div class="subpanel-inner">
+          <%- partial('../_partials/solutions/lead.ejs') %>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-3">
+      <div class="subpanel">
+        <div class="subpanel-inner">
+          <%- partial('../_partials/cards/corner-pocket.ejs') %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/styleguide/derek/solutions/solutions-usage.ejs
+++ b/styleguide/derek/solutions/solutions-usage.ejs
@@ -61,6 +61,40 @@
 
 <hr>
 
+<!-- Lead -->
+<div class="container">
+  <h4>Split Lead/ Corner Pocket</h4>
+  <h6>Required Fileds for Corner Pocket: Pre-headline, Callout</h6>
+  <p>The corner pocket should be used to feature pricing. It has three available fields but the first two are the only required fields.</p>
+  <div class="row">
+    <div class="col-md-6">
+      <h4 class="red">DO</h4>
+      <ul class="checks">
+        <li>Include compelling pricing</li>
+        <li>Use with the left aligned lead</li>
+        <li>Put lead and corner pocket in a subpanel well in order to get alignment</li>
+      </ul>
+    </div>
+    <div class="col-md-6">
+      <h4 class="red">DONT</h4>
+      <ul class="times">
+        <li>Use for promotions, that is to be used with the anouncements pattern</li>
+        <li>Use for PDFs or other call outs. Only to be used for pricing.</li>
+        <li> Do not use with an equal height container</li>
+      </ul>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <h5 class="red">Example:</h5>
+      <%- partial('../layouts/leadCornerPocket.ejs') %>
+    </div>
+  </div>
+</div>
+
+<hr>
+
+
 <!-- Text -->
 <div class="container">
   <h4>Text</h4>

--- a/styleguide/derek/solutions/solutions.ejs
+++ b/styleguide/derek/solutions/solutions.ejs
@@ -16,6 +16,8 @@
   </div>
 </div>
 
+<%- partial('../layouts/leadCornerPocket.ejs') %>
+
 
 <%- partial('../layouts/key-offers.ejs') %>
 <%- partial('../layouts/valueProps.ejs') %>

--- a/styleguide/derek/templates/landing-page/video-LP.ejs
+++ b/styleguide/derek/templates/landing-page/video-LP.ejs
@@ -7,10 +7,18 @@
   <div class="container standard-padding-top">
     <div class="row flex-row">
       <div class="col-md-6 flex-all">
-        <%- partial("../../_partials/solutions/lead.ejs") %>
+        <div class="subpanel">
+          <div class="subpanel-inner">
+            <%- partial("../../_partials/solutions/lead.ejs") %>
+          </div>
+        </div>
       </div>
       <div class="col-md-6 flex-all">
-        <%- partial("../../_partials/solutions/video.ejs") %>
+        <div class="subpanel">
+          <div class="subpanel-inner">
+            <%- partial("../../_partials/solutions/video.ejs") %>
+          </div>
+        </div>
       </div>
     </div>
     <%- partial('../layouts/valueProps.ejs') %>

--- a/styleguide/derek/templates/section-overview.ejs
+++ b/styleguide/derek/templates/section-overview.ejs
@@ -7,10 +7,18 @@
   <div class="container standard-padding-top">
     <div class="row flex-row">
       <div class="col-md-6 flex-all">
-        <%- partial("../_partials/solutions/lead.ejs") %>
+        <div class="subpanel">
+          <div class="subpanel-inner">
+            <%- partial("../_partials/solutions/lead.ejs") %>
+          </div>
+        </div>
       </div>
       <div class="col-md-6 flex-all">
-        <%- partial("../_partials/solutions/video.ejs") %>
+        <div class="subpanel">
+          <div class="subpanel-inner">
+            <%- partial("../_partials/solutions/video.ejs") %>
+          </div>
+        </div>
       </div>
     </div>
     <%- partial('layouts/valueProps.ejs') %>


### PR DESCRIPTION
RSWEB-8523
Addition of new corner pocket card. Included on solutions pages with documentation and added in the partial of leadSplit to account for the left aligned lead that we use in splits in www.