### PR TITLE
rsweb-7582-list-bug-mobile

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/cards/modules.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/modules.scss
@@ -17,6 +17,10 @@
   margin: 0;
 }
 
+.list-wrapper {
+  width: 100%;
+}
+
 .expertise-container {
   background-size: cover;
   padding: 60px 0;

--- a/styleguide/derek/_partials/cards/list.ejs
+++ b/styleguide/derek/_partials/cards/list.ejs
@@ -3,12 +3,14 @@
 <% if(!items) { var items = ["Live, US-based support team", "Remotely log in and troubleshoot Virtual Machines, OS and Apps", "Dedicated account team", "15-Minute Response Time SLA to monitoring notifications"]; } %>
 
 <!-- Features List Pattern -->
-<div class="col-xs-12">
-  <h4 class="center">Optional List Title</h4>
-  <ul class="<%- list_classes %>">
-    <% items.forEach(function(item){ %>
-      <li><%- item %></li>
-    <% }) %>
-      <li><a href="javascript:void(0)">This is an example of a link in the List pattern.</a></li>
-  </ul>
+<div class="list-wrapper">
+  <div class="col-xs-12">
+    <h4 class="center">Optional List Title</h4>
+    <ul class="<%- list_classes %>">
+      <% items.forEach(function(item){ %>
+        <li><%- item %></li>
+      <% }) %>
+        <li><a href="javascript:void(0)">This is an example of a link in the List pattern.</a></li>
+    </ul>
+  </div>
 </div>


### PR DESCRIPTION
RSWEB-7582

Fixing mobile list bug and adding list-wrapper to list pattern in zoolander (its already in www)
Visible on this page in zoolander:
http://localhost:9000/derek/solutions/solutions-usage
under the features section

Visible on these pages in www:
https://www.rackspace.com/email-hosting/webmail/features
https://www.rackspace.com/cloud/servers
