### PR TITLE
RSWEB-8705: consistent gutters

### DIFF
--- a/styleguide/_themes/global/scss/banners.scss
+++ b/styleguide/_themes/global/scss/banners.scss
@@ -22,10 +22,7 @@
 .imacBanner-container {
   @include make-container;
   @include fadein(1s);
-}
-
-.imacBanner-textRow {
-  @include make-row;
+  padding: 0 45px;
 }
 
 .imacBanner-headlineLarge {
@@ -54,6 +51,11 @@
   margin: 0 auto;
   padding: 15px;
   position: relative;
+}
+
+.imacBanner-textRow {
+  @include make-row;
+  padding: 0 25px;
 }
 
 .imacBanner-buttonRow {
@@ -113,7 +115,11 @@
 @media only screen and (max-width: $screen-sm-max) {
   .imacBanner {
     height: 250px;
-    padding: 50px 15px;
+    padding: 50px 0;
+  }
+
+  .imacBanner-container {
+    padding: 0 35px;
   }
 
   .imacBanner-withCta {

--- a/styleguide/derek/global-components/basement/_basement.scss
+++ b/styleguide/derek/global-components/basement/_basement.scss
@@ -21,7 +21,7 @@
 
 .basement-container {
   @include make-container;
-  padding: 10px 0;
+  padding: 10px 25px;
 }
 
 .basement-copyright {

--- a/styleguide/derek/global-components/ceiling/_ceiling.scss
+++ b/styleguide/derek/global-components/ceiling/_ceiling.scss
@@ -2,24 +2,23 @@
 
 $ceiling-margin: floor($navbar-margin-bottom / 4);
 $navigation-font-size: 1.2rem;
-$navigation-font-size-medium: 1.15rem;
+$navigation-font-size-medium: 1.05rem;
+$navigation-font-size-xsmall: .9rem;
+$ceiling-font-size: $navigation-font-size-medium;
 
 .ceiling {
   background: $gray-dark;
   border: 0;
   border-radius: 0;
   font-family: $copy;
-  font-size: $navigation-font-size-medium;
+  font-size: $ceiling-font-size;
   font-weight: $font-weight-black;
   margin: 0;
   min-height: $line-height-computed;
 }
 
 .ceiling-container {
-  margin: 0 auto;
-  max-width: 1280px;
-  padding: 0 5px;
-  width: 100%;
+  @include make-container;
 }
 
 .navbar-phoneicon {
@@ -149,7 +148,7 @@ $navigation-font-size-medium: 1.15rem;
 
 .ceiling-dropdownMenu-item {
   color: $white;
-  font-size: $navigation-font-size-medium;
+  font-size: $ceiling-font-size;
   margin: 0;
   padding: 0;
 
@@ -188,6 +187,10 @@ $navigation-font-size-medium: 1.15rem;
 @media screen and (max-width: $screen-xs-max) {
   .ceiling-menuInline-item {
     font-size: 1rem;
+  }
+
+  .ceiling-container {
+    padding: 0;
   }
 }
 

--- a/styleguide/derek/global-components/ceiling/_ceilingLp.scss
+++ b/styleguide/derek/global-components/ceiling/_ceilingLp.scss
@@ -36,10 +36,6 @@
   max-width: $full-width;
 }
 
-.ceilingLp-container {
-  padding: 0;
-}
-
 .ceilingLp-menuInline {
   list-style: none;
   margin-bottom: 0;
@@ -47,7 +43,7 @@
 
 .ceilingLp-menuInline-item {
   display: inline-block;
-  font-size: 1.4rem;
+  font-size: $navigation-font-size;
   font-weight: $font-weight-black;
   margin: 0;
   padding: 0 floor($ceiling-margin + 2);

--- a/styleguide/derek/global-components/ceiling/ceiling.ejs
+++ b/styleguide/derek/global-components/ceiling/ceiling.ejs
@@ -1,6 +1,6 @@
 <div class="navbar-fixed-top">
   <div class="ceiling">
-      <div class="container ceiling-container">
+      <div class="ceiling-container">
           <a class="navbar-brand" href=""><span class="sr-only">Rackspace the #1 managed cloud company</span></a>
           <nav class="ceiling-menuNav">
               <ul class="ceiling-menuInline" role="menu">

--- a/styleguide/derek/global-components/footer/_footer.scss
+++ b/styleguide/derek/global-components/footer/_footer.scss
@@ -1,10 +1,10 @@
 .footer {
   background-color: $gray-dark;
+  padding: 20px 0;
 }
 
 .footer-container {
   @include make-container;
-  padding: 0;
 }
 
 .footer-menu {

--- a/styleguide/derek/global-components/footer/footer.ejs
+++ b/styleguide/derek/global-components/footer/footer.ejs
@@ -1,5 +1,5 @@
 <!--[footernav]-->
-<div class="half-padding-full footer">
+<div class="footer">
   <div class="footer-container">
     <ul id="footer-accordion" class="footer-tabs">
       <li class="col-sm-6"><a href="#footer-tab-1" class="footer-tab-link" data-toggle="tab">About Rackspace</a></li>

--- a/styleguide/derek/global-components/nav/_nav.scss
+++ b/styleguide/derek/global-components/nav/_nav.scss
@@ -5,12 +5,10 @@
   box-shadow: 0 6px 12px $black-shadow;
   font-family: $copy;
   margin: 0;
+}
 
-  .navbar-menuContainer {
-    border: 0;
-    max-height: none;
-    padding: 0;
-  }
+.navbar-container {
+  @include make-container;
 }
 
 .navbar-nav {
@@ -21,7 +19,7 @@
     display: block;
     font-weight: $font-weight-black;
     line-height: 2.1rem;
-    padding: 20px 19px 17px;
+    padding: 20px 20px 17px;
     text-decoration: none;
 
     &:hover,
@@ -75,12 +73,6 @@
   }
 }
 
-.navbar-container {
-  margin: 0 auto;
-  max-width: 1280px;
-  padding: 0;
-}
-
 //make sure menu aligns with right side of buttons in desktop
 .navbar-menu {
   float: left;
@@ -128,7 +120,7 @@
   background-repeat: no-repeat;
   background-size: 100% 79%;
   height: 35px;
-  margin: 5px 10px;
+  margin: 5px;
   position: relative;
   transition-duration: .3s;
   width: 150px;
@@ -210,6 +202,14 @@
 }
 
 @media only screen and (max-width: $screen-xs-max) {
+
+  .navbar-container {
+    padding: 0;
+  }
+
+  .navbar-menuContainer {
+    padding: 0;
+  }
 
   //mainnav side caret for dropdowns
   .navbar-dropDown-trigger {
@@ -352,7 +352,7 @@
   background: $white;
   border: 0;
   border-left: 1px solid $gray-base;
-  font-size: 1.25rem;
+  font-size: $navigation-font-size-medium;
   height: 100%;
   margin: 0;
   min-height: 61px;

--- a/styleguide/derek/global-components/nav/nav.ejs
+++ b/styleguide/derek/global-components/nav/nav.ejs
@@ -11,7 +11,7 @@
       	</div>
         <div class="collapse navbar-collapse navbar-menuContainer" id="main-navigation">
           <ul class="nav navbar-nav navbar-menu">
-            <li class="navbar-topItem"><a href="javascript:void(0)" class="navbar-topLink">Why Rackspace</a></li>
+            <li class="navbar-topItem"><a href="javascript:void(0)" class="navbar-topLink">About</a></li>
             <li class="navbar-topItem"><a href="javascript:void(0)" class="navbar-topLink">Dedicated Hosting</a></li>
             <li class="navbar-topItem">
               <span class="navbar-topLink navbar-topLink-dropDown" data-toggle="dropdown" role="button" aria-expanded="false">Cloud</span>

--- a/styleguide/derek/global-components/rug/_rug.scss
+++ b/styleguide/derek/global-components/rug/_rug.scss
@@ -5,7 +5,6 @@
 
 .rug-wrapper {
   @include make-container;
-  padding: 0;
 }
 
 .rug-headerWrapper {
@@ -84,6 +83,11 @@
 @media only screen and (max-width: $screen-md-max) {
   .rug-subhead {
     font-size: 1rem;
+    line-height: 1.25rem;
+  }
+
+  .rug-head {
+    font-size: 1.65rem;
   }
 }
 

--- a/styleguide/derek/global-components/subnav/_subnav.scss
+++ b/styleguide/derek/global-components/subnav/_subnav.scss
@@ -5,9 +5,7 @@
 }
 
 .subnav-container {
-  margin: 0 auto;
-  max-width: $screen-md-max;
-  padding: 0;
+  @include make-container;
 }
 
 .subnav-links {
@@ -23,7 +21,7 @@
   font-size: $navigation-font-size;
   font-weight: $font-weight-black;
   line-height: 2.1rem;
-  padding: 20px 13px 17px;
+  padding: 20px 20px 17px;
   text-decoration: none;
 
   &:hover,
@@ -49,11 +47,13 @@
 
 .subnav-toggleBtn {
   float: left;
-  margin: 14px 0;
+  margin: 17px 10px;
   padding: 0;
 
   .subnav-iconBar {
-    height: 3px;
+    border-radius: 0;
+    height: 2px;
+    width: 18px;
   }
 }
 
@@ -72,7 +72,7 @@
 }
 
 .subnav-collapseContainer {
-  padding: 0 1px;
+  padding: 0;
 }
 
 .subnav-item {
@@ -112,22 +112,45 @@
 @media only screen and (max-width: $screen-md-max) {
   .subnav-item {
     border-bottom: 0;
-    font-size: .9em;
-    padding: 0 5px;
   }
 
+  .subnav-link {
+    font-size: $navigation-font-size;
+    padding: 19px 23px;
+  }
+
+  .subnav-leadBtn {
+    font-size: $navigation-font-size-medium;
+  }
+}
+
+@media only screen and (max-width: $screen-sm-max) {
   .subnav-container {
-    width: 100%;
+    max-width: $screen-md;
+  }
+
+  .subnav-link {
+    font-size: $navigation-font-size-medium;
+    padding: 19px 10px;
   }
 }
 
 @media only screen and (max-width: $screen-xs-max) {
+  .subnav-container {
+    padding: 0;
+  }
+
+  .subnav-collapseContainer {
+    padding: 0 1px;
+  }
+
   .subnav-links {
     padding-top: 5px;
   }
 
   .subnav-link {
     border-bottom: 0;
+    font-size: $navigation-font-size-xsmall;
 
     &:hover {
       border-bottom: 0;

--- a/styleguide/derek/incubation/homepage.ejs
+++ b/styleguide/derek/incubation/homepage.ejs
@@ -180,7 +180,7 @@
 
 
   <!-- Testimonials -->
-  <div class="bg-steel-blue standard-padding">
+  <div class="bg-gray-dark standard-padding">
     <div class="container">
       <div id="quote">
         <div class="row">
@@ -211,7 +211,7 @@
   </div>
 
   <!-- logo river -->
-  <div class="container-fluid half-padding bg-steel-blue">
+  <div class="container-fluid half-padding bg-gray-dark">
     <div class="container logoShowcase">
       <ul class="logoShowcase-row">
         <li class="logoShowcase-logoItem">

--- a/styleguide/derek/incubation/office365.ejs
+++ b/styleguide/derek/incubation/office365.ejs
@@ -2690,3 +2690,7 @@
 
   <!-- End Overview - Features -->
 </div>
+
+<%- partial("../_partials/_rug") %>
+<%- partial("../_partials/_footer") %>
+<%- partial("../_partials/_basement") %>

--- a/styleguide/derek/templates/section-overview.ejs
+++ b/styleguide/derek/templates/section-overview.ejs
@@ -4,7 +4,9 @@
 <div class="contentOffset">
   <%- partial("../_partials/solutions/header-mediumIMAC.ejs") %>
 
-  <div class="container standard-padding-top">
+  <%- partial("../_partials/solutions/subnav") %>
+
+  <div class="container standard-padding">
     <div class="row flex-row">
       <div class="col-md-6 flex-all">
         <div class="subpanel">
@@ -51,5 +53,9 @@
 
   <%- partial("../_partials/solutions/cta-bottom.ejs") %>
 
-  <%- partial("../_partials/solutions/footer.ejs") %>
+  <%- partial("../_partials/_rug") %>
+
+  <%- partial("../_partials/_footer") %>
+
+  <%- partial("../_partials/_basement") %>
 </div>


### PR DESCRIPTION
RSWEB-8705 
Getting the gutters into some semblance of normal.

You may notice some additional padding on the rug, footer, basement and imac banner containers. In order to have those elements align with the beginning of the actual word of the links in the main navigation and subnav instead of the beginning of the padded link container (you can see this on those links hover states) those containers got some extra padding. The actual first word of those links also now match up with the left side of the page elements, which is why I didnt instead remove padding from the main nav and subnav. 

Should only need to remove the container declaration from the ceiling in www

This can best be seen on this page:
http://localhost:9000/derek/templates/section-overview