### PR TITLE
fix(global): link styles

### DIFF
--- a/styleguide/_themes/derek/scss/patterns/cards/modules.scss
+++ b/styleguide/_themes/derek/scss/patterns/cards/modules.scss
@@ -84,12 +84,10 @@
   margin: 10px;
 }
 
-.node-text > a {
-  @include standard-link;
-}
-
-.node-general > a {
-  @include standard-link;
+.node-text {
+  a {
+    @include standard-link;
+  }
 }
 
 .calculator {


### PR DESCRIPTION
RSWEB-8793

Wanted all links in text and generals to have the link style, not just top level. Ran into the problem where links are nested in lists and they arent styling.