### PR TITLE
RSWEB-8848: Add live reload

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -1,0 +1,17 @@
+/*
+ |--------------------------------------------------------------------------
+ | Browser-sync config file
+ |--------------------------------------------------------------------------
+ |
+ | For up-to-date information about the options:
+ |   http://www.browsersync.io/docs/options/
+ |
+ | There are more options than you see here, these are just the ones that are
+ | set internally. See the website for more info.
+ |
+ |
+ */
+module.exports = {
+  files: ['styleguide/js/**/**/*.js', 'styleguide/_themes/**/**/*.scss'],
+  proxy: 'localhost:9000',
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "harp": "harp ",
     "harp:compile": "npm run harp compile styleguide dist",
-    "start": "harp server styleguide",
+    "start": "concurrently 'harp server styleguide' 'browser-sync start --config bs-config.js'",
     "gh-pages": "./scripts/build-pages.sh",
     "preversion": "npm run babel && npm run harp compile styleguide dist && git add -f dist",
     "postversion": "git push && git push --tags",
@@ -24,11 +24,13 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap-sass": "^3.3.6",
+    "concurrently": "^3.4.0",
     "harp": "^0.20.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-preset-env": "^1.2.2",
+    "browser-sync": "^2.18.8",
     "eslint": "^3.18.0",
     "eslint-config-airbnb-base": "^11.1.2",
     "eslint-plugin-import": "^2.2.0",

--- a/styleguide/_layouts/default.jade
+++ b/styleguide/_layouts/default.jade
@@ -24,6 +24,7 @@ html(lang="en")
     script(src="https://577351e10bc4a0198d93-f60a0bb748a3c84145bb10da7563bafb.ssl.cf1.rackcdn.com/zoolander/jquery.fittext.js")
     script(src="https://577351e10bc4a0198d93-f60a0bb748a3c84145bb10da7563bafb.ssl.cf1.rackcdn.com/zoolander/bootstrap-tabcollapse.js")
 
+  body
     .row.row-eq-height
       button.navZoolander-slideBtn.navZoolander-leftArrow
       .navZoolander-container
@@ -82,10 +83,10 @@ html(lang="en")
               li.navZoolander-item
                 a(href="derek/incubation").navZoolander-dropdownLink Dev Sandbox
 
-  .mainContainer#mainContainer
-    block content
+    .mainContainer#mainContainer
+      block content
 
-  script(src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous")
-  script(src="#{base}js/global.js")
-  script.
-    $(".imacBanner-headline").fitText(1.1, { maxFontSize: '45px' });
+    script(src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous")
+    script(src="#{base}js/global.js")
+    script.
+      $(".imacBanner-headline").fitText(1.1, { maxFontSize: '45px' });


### PR DESCRIPTION
https://jira.rax.io/browse/RSWEB-8848

Change summary:
* Add browser sync
* Add script for starting browser sync
* Add browser sync snip for injecting updates

Instructions:
1. npm install
2. npm run babel
3. npm start
4. npm bs-start
5. navigate to http://localhost:3000/derek/templates/landing-page/video-LP
6. go edit styleguide/_themes/derek/scss/patterns/quote.scss , save
7. view your browser again .. should update
8. also go look at your terminal where you're running browsersync, you should see:
<img width="589" alt="1__npm_run_bs-start__node_" src="https://cloud.githubusercontent.com/assets/8450357/24477602/3bfed564-149d-11e7-9e9a-0a9172189200.png">


- - - - - - - 
To be discussed:
do we want to implement it this way with the snip added?
what files do we want to watch?
do we want browser sync to start when you start harp, or keep it a separate command?