### PR TITLE
RSWEB-8999: [Bug] Ceiling link font size inconsistent

### DIFF
--- a/styleguide/derek/global-components/ceiling/_ceiling.scss
+++ b/styleguide/derek/global-components/ceiling/_ceiling.scss
@@ -98,7 +98,7 @@ $ceiling-font-size: $navigation-font-size-medium;
 .ceiling-menuInline-link {
   color: $white;
   display: block;
-  font-size: $navigation-font-size-medium;
+  font-size: 1.15rem;
   padding: 15px floor($ceiling-margin + 5);
   text-decoration: none;
   vertical-align: middle;
@@ -160,7 +160,7 @@ $ceiling-font-size: $navigation-font-size-medium;
 .ceiling-dropdownToggle {
   color: $white;
   display: block;
-  font-size: $navigation-font-size-medium;
+  font-size: 1.15rem;
   padding: 15px floor($ceiling-margin + 5);
   text-decoration: none;
 


### PR DESCRIPTION
Change summary:

* Set font size to a unified 1.15rem for ceiling

specifically, I put the vars in play, updated the `$navigation-font-size-medium` value so that it matches what the other nav items are. In line 86 I set that class to use the same var so that they're all unified. . . . 