### PR TITLE
refactor(derek): add class for padded container in zoolander

### DIFF
--- a/styleguide/_themes/global/scss/modifiers.scss
+++ b/styleguide/_themes/global/scss/modifiers.scss
@@ -17,6 +17,11 @@ $uppercase: uppercase;
 img { max-width: 100%; }
 
 // Layout
+.derek-paddedContainer {
+  @include make-container;
+  padding: $standard-padding;
+}
+
 .full-width {
   width: $full-width;
 }

--- a/styleguide/derek/incubation/homepage.ejs
+++ b/styleguide/derek/incubation/homepage.ejs
@@ -1,6 +1,6 @@
 <%- partial("../pattern-components/headers/header-large-imac.ejs") %>
 
-<div class="container half-padding hostingOptions">
+<div class="derek-paddedContainer hostingOptions">
 	<div class="row half-padding-full">
 		<div class="col-md-11 center-block">
 			<h1 class="text-center no-margin no-padding" id="homepage-lead-top">Rackspace is the largest managed cloud provider</h1>

--- a/styleguide/derek/incubation/office365.ejs
+++ b/styleguide/derek/incubation/office365.ejs
@@ -16,7 +16,7 @@
   </div>
 
   <!-- Value Prop section-->
-  <div class="container value-prop-container rocket standard-padding">
+  <div class="derek-paddedContainer value-prop-container rocket">
     <div class="row">
       <div class="col-md-4 col-sm-6">
         <div class="value-prop">

--- a/styleguide/derek/pattern-components/awards/awards.ejs
+++ b/styleguide/derek/pattern-components/awards/awards.ejs
@@ -1,5 +1,5 @@
 <!-- Awards Cert: 33/33/33 -->
-<div class="container half-padding">
+<div class="derek-paddedContainer">
   <div class="row">
     <div class="col-sm-4">
       <%- partial('_partials/award.ejs', {subhead: 'RedHat certifications'}) %>

--- a/styleguide/derek/pattern-components/business-resources/business-resources.ejs
+++ b/styleguide/derek/pattern-components/business-resources/business-resources.ejs
@@ -1,5 +1,5 @@
 <!-- Business Resources: 33/67 -->
-<div class="container half-padding">
+<div class="derek-paddedContainer">
   <h4>Business Resources</h4>
   <div class="row row-eq-height">
     <div class="col-sm-4 panel-flex">

--- a/styleguide/derek/pattern-components/ias/ias.ejs
+++ b/styleguide/derek/pattern-components/ias/ias.ejs
@@ -1,5 +1,5 @@
 <!-- IAS: 33/34/33 -->
-<div class="container half-padding">
+<div class="derek-paddedContainer">
   <div class="row row-eq-height">
     <div class="col-sm-4 panel-flex">
       <%- partial('_partials/ias.ejs') %>

--- a/styleguide/derek/pattern-components/leads/lead-corner-pocket/lead-corner-pocket.ejs
+++ b/styleguide/derek/pattern-components/leads/lead-corner-pocket/lead-corner-pocket.ejs
@@ -1,4 +1,4 @@
-<div class="container half-padding-full">
+<div class="derek-paddedContainer">
   <div class="row">
     <div class="col-sm-9">
       <div class="subpanel">

--- a/styleguide/derek/pattern-components/leads/lead-full-width/lead-full-width.ejs
+++ b/styleguide/derek/pattern-components/leads/lead-full-width/lead-full-width.ejs
@@ -1,3 +1,3 @@
-<div class="container standard-padding">
+<div class="derek-paddedContainer">
   <%- partial('../lead/lead.ejs') %>
 </div>

--- a/styleguide/derek/pattern-components/leads/lead-image/lead-image.ejs
+++ b/styleguide/derek/pattern-components/leads/lead-image/lead-image.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding-top">
+<div class="derek-paddedContainer">
   <div class="row flex-row">
     <div class="col-md-9 flex-all">
       <div class="subpanel">

--- a/styleguide/derek/pattern-components/leads/lead-video/lead-video.ejs
+++ b/styleguide/derek/pattern-components/leads/lead-video/lead-video.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding-top">
+<div class="derek-paddedContainer">
   <div class="row flex-row">
     <div class="col-md-9 flex-all">
       <div class="subpanel">

--- a/styleguide/derek/pattern-components/lists/lists.ejs
+++ b/styleguide/derek/pattern-components/lists/lists.ejs
@@ -1,16 +1,14 @@
 <!-- List: 33/34/33 -->
-<div class="half-padding-top">
-  <div class="container">
-    <div class="row row-eq-height">
-      <div class="col-md-4 panel-flex">
-        <%- partial("_partials/list", {list_classes: "discs"}) %>
-      </div>
-      <div class="col-md-4 panel-flex">
-        <%- partial("_partials/list", {list_classes: "checks green"}) %>
-      </div>
-      <div class="col-md-4 panel-flex">
-        <%- partial("_partials/list", {items: ["Live, US-based support team", "Remotely log in and troubleshoot Virtual Machines, OS and Apps", "Dedicated account team", "15-Minute Response Time SLA to monitoring notifications", "Live, US-based support team", "Live, US-based support team"]}) %>
-      </div>
+<div class="derek-paddedContainer">
+  <div class="row row-eq-height">
+    <div class="col-md-4 panel-flex">
+      <%- partial("_partials/list", {list_classes: "discs"}) %>
+    </div>
+    <div class="col-md-4 panel-flex">
+      <%- partial("_partials/list", {list_classes: "checks green"}) %>
+    </div>
+    <div class="col-md-4 panel-flex">
+      <%- partial("_partials/list", {items: ["Live, US-based support team", "Remotely log in and troubleshoot Virtual Machines, OS and Apps", "Dedicated account team", "15-Minute Response Time SLA to monitoring notifications", "Live, US-based support team", "Live, US-based support team"]}) %>
     </div>
   </div>
 </div>

--- a/styleguide/derek/pattern-components/service-level-teaser/service-level-teaser.ejs
+++ b/styleguide/derek/pattern-components/service-level-teaser/service-level-teaser.ejs
@@ -3,34 +3,32 @@
 </div>
 
 <!-- Service Level Teaser -->
-<div class="half-padding">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Human Experts",
-          icon: "idio-winner",
-          price: "$500/m"
-        }) %>
-      </div>
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Navigator",
-          icon: "srv-navigator",
-          price: "$600/m"
-        }) %>
-      </div>
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Aviator",
-          icon: "srv-aviator",
-          price: "$700/m"
-        }) %>
-      </div>
+<div class="derek-paddedContainer">
+  <div class="row">
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Human Experts",
+        icon: "idio-winner",
+        price: "$500/m"
+      }) %>
     </div>
-    <div class="serviceLevelTeaser-bottom">
-      <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Navigator",
+        icon: "srv-navigator",
+        price: "$600/m"
+      }) %>
     </div>
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Aviator",
+        icon: "srv-aviator",
+        price: "$700/m"
+      }) %>
+    </div>
+  </div>
+  <div class="serviceLevelTeaser-bottom">
+    <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
   </div>
 </div>
 
@@ -39,27 +37,25 @@
 </div>
 
 <!-- Teaser with only 2 option -->
-<div class="half-padding">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-4 col-sm-push-2">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Human Experts",
-          icon: "idio-winner",
-          price: "$500/m"
-        }) %>
-      </div>
-      <div class="col-sm-4 col-sm-push-2">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Navigator",
-          icon: "srv-navigator",
-          price: "$600/m"
-        }) %>
-      </div>
+<div class="derek-paddedContainer">
+  <div class="row">
+    <div class="col-sm-4 col-sm-push-2">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Human Experts",
+        icon: "idio-winner",
+        price: "$500/m"
+      }) %>
     </div>
-    <div class="serviceLevelTeaser-bottom">
-      <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
+    <div class="col-sm-4 col-sm-push-2">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Navigator",
+        icon: "srv-navigator",
+        price: "$600/m"
+      }) %>
     </div>
+  </div>
+  <div class="serviceLevelTeaser-bottom">
+    <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
   </div>
 </div>
 
@@ -67,36 +63,34 @@
   <h3>Service Level Teasers (stand out option)</h3>
 </div>
 <!-- Teaser with a standout option -->
-<div class="half-padding">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Human Experts",
-          icon: "idio-winner",
-          price: "$500/m",
-          standoutClass: "serviceLevelTeaser-default"
-        }) %>
-      </div>
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Navigator",
-          icon: "srv-navigator",
-          price: "$600/m",
-          standoutClass: "serviceLevelTeaser-standOut"
-        }) %>
-      </div>
-      <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
-          title: "Aviator",
-          icon: "srv-aviator",
-          price: "$700/m",
-          standoutClass: "serviceLevelTeaser-default"
-        }) %>
-      </div>
+<div class="derek-paddedContainer">
+  <div class="row">
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Human Experts",
+        icon: "idio-winner",
+        price: "$500/m",
+        standoutClass: "serviceLevelTeaser-default"
+      }) %>
     </div>
-    <div class="serviceLevelTeaser-bottom">
-      <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Navigator",
+        icon: "srv-navigator",
+        price: "$600/m",
+        standoutClass: "serviceLevelTeaser-standOut"
+      }) %>
     </div>
+    <div class="col-sm-4">
+      <%- partial('_partials/teaser.ejs', {
+        title: "Aviator",
+        icon: "srv-aviator",
+        price: "$700/m",
+        standoutClass: "serviceLevelTeaser-default"
+      }) %>
+    </div>
+  </div>
+  <div class="serviceLevelTeaser-bottom">
+    <a href="#" class="serviceLevelTeaser-bottomLink">Compare All</a>
   </div>
 </div>

--- a/styleguide/derek/pattern-components/value-props/value-props.ejs
+++ b/styleguide/derek/pattern-components/value-props/value-props.ejs
@@ -1,5 +1,5 @@
 <!-- Value Props: 33/34/33 -->
-<div class="container half-padding">
+<div class="derek-paddedContainer">
   <div class="row row-eq-height">
     <div class="col-sm-4 panel-flex">
       <%- partial('_partials/value-prop.ejs') %>

--- a/styleguide/derek/solutions/solutions-usage.ejs
+++ b/styleguide/derek/solutions/solutions-usage.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding-full">
+<div class="container">
   <h5 class="red">Global Ecomm Pattern Usage Guidelines</h5>
   <h2 class="no-margin">How to put our patterns to work for you</h2>
   <p>We love our patterns and there are guidelines to using them so they can be as consistent and maintainable as possible. So here are the Dos and Don'ts of using our patterns in general</p>

--- a/styleguide/derek/solutions/solutions.ejs
+++ b/styleguide/derek/solutions/solutions.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding-full">
+<div class="container">
   <h5 class="red">Global Ecomm Pattern Library</h5>
   <h2 class="no-margin">The building blocks for your pages</h2>
   <p>We love our patterns and there are guidelines to using them so they can be as consistent and maintainable as possible. So here are the Dos and Don'ts of using our patterns</p>

--- a/styleguide/derek/view-templates/leadership/leadership-interior.ejs
+++ b/styleguide/derek/view-templates/leadership/leadership-interior.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding">
+<div class="derek-paddedContainer">
   <div class="row">
     <div class="col-md-3">
       <div class="subpanel">

--- a/styleguide/derek/view-templates/leadership/leadership.ejs
+++ b/styleguide/derek/view-templates/leadership/leadership.ejs
@@ -1,4 +1,4 @@
-<div class="container standard-padding">
+<div class="derek-paddedContainer">
   <%- partial('../../pattern-components/leads/lead/lead.ejs', { desc: 'Beginning with our founders—Richard Yoo, Pat Condon, Dirk Elmendorf, Morris Miller and Graham Weston—our leaders have guided our company to do whats best and right for the hundreds of thousands of businesses that depend on us. Meet the individuals who help make Rackspace great.' }) %>
   <div class="row half-padding">
     <h2 class="center">Global Leadership</h2>

--- a/styleguide/index.jade
+++ b/styleguide/index.jade
@@ -1,7 +1,7 @@
 extends ./_layouts/default.jade
 
 block content
-  .container.standard-padding
+  .derek-paddedContainer
     .row
       .col-lg-12
         h4.red Welcome Friends &amp; Family


### PR DESCRIPTION
RSWEB-9033

Add a maintainable class for a padded container in zoolander. 
Switched out some of the containers with padding in zoolander to show the usage. 
However, because we havent gotten all the padding situation figured out with the standard-padding-full things look a little wonk on the solutions pages.

But the actual padded container class is on some of the patterns and is in modifiers.