### PR TITLE
RSWEB-9199: Featured resource graphic moved to background image

### DIFF
--- a/styleguide/derek/view-templates/resource-center/_resource-center.scss
+++ b/styleguide/derek/view-templates/resource-center/_resource-center.scss
@@ -120,8 +120,7 @@
 }
 
 .resourcecenter-featuredGraphicWrapper {
-  @include make-md-column(3);
-  margin-top: -90px;
+  display: none;
 }
 
 .resourcecenter-featuredTextWrapper {
@@ -151,14 +150,30 @@
   padding: 2rem 0;
 }
 
-@media screen and (max-width: $screen-sm-max) {
+@media screen and (min-width: $screen-md-min) {
   .resourcecenter-featuredGraphicWrapper {
-    display: none;
+    @include make-md-column(3);
+    background-image: url('https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/resource-center/pdf-template-graphic.png');
+    background-position: center bottom;
+    background-repeat: no-repeat;
+    background-size: 83.5%;
+    display: block;
+    height: 280px;
+    margin-bottom: 1px;
+    margin-top: -90px;
+  }
+
+  .resourcecenter-featuredGraphic {
+    margin-left: 20px;
+    margin-top: 76px;
+    width: 87%;
   }
 }
 
-@media screen and (min-width: $screen-sm-min) and (max-width: $screen-md-max) {
-  .resourcecenter-featuredGraphicWrapper {
-    margin-top: 0;
+@media screen and (min-width: $screen-lg-min) {
+  .resourcecenter-featuredGraphic {
+    margin-left: 34px;
+    margin-top: 14px;
+    width: 81.5%;
   }
 }

--- a/styleguide/derek/view-templates/resource-center/resource-center.ejs
+++ b/styleguide/derek/view-templates/resource-center/resource-center.ejs
@@ -5,11 +5,13 @@
 <div class="resourcecenter-featuredResourceWrapper">
   <div class="resourcecenter-featuredResourceContainer">
     <div class="resourcecenter-featuredGraphicWrapper">
-      <img class="resourcecenter-featuredGraphic" src="http://034d24a88b3e71fd72a6-f083e9a6295a3f0714fa019ffdca65c3.r47.cf1.rackcdn.com/resource-center/pdf-template-graphic.png"/>
+      <img class="resourcecenter-featuredGraphic" src="http://034d24a88b3e71fd72a6-f083e9a6295a3f0714fa019ffdca65c3.r47.cf1.rackcdn.com/resource-center/testpdf.jpg">
     </div>
     <div class="resourcecenter-featuredTextWrapper">
       <h3 class="resourcecenter-featuredTextTitle">Resource Title Here</h3>
-      <p class="resourcecenter-featuredTextDesc">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mpsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.</p>
+      <div class="resourcecenter-featuredTextDesc">
+        <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mpsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.</p>
+      </div>
       <a class="resourcecenter-featuredTextLink">View Resource</a>
     </div>
   </div>
@@ -61,4 +63,3 @@
   </div>
 </div>
 <script src="js/global-components/filter-bar/filtering.js" charset="utf-8"></script>
-


### PR DESCRIPTION
This PR moves the featured resource graphic into the background instead of being explicitly added to behave like detailed resource graphic. This allows us to sit an image for an individual resource on top of the background. 