### PR TITLE
fix(bug): resource button style after visit

### DIFF
--- a/styleguide/derek/view-templates/resource-center/_resource-center.scss
+++ b/styleguide/derek/view-templates/resource-center/_resource-center.scss
@@ -83,6 +83,12 @@
 .resourcecenter-button {
   @include button;
   @include button-download;
+
+  &:link,
+  &:visited {
+    color: $white;
+    text-decoration: none;
+  }
 }
 
 .resourcecenter-dividerWrapper {


### PR DESCRIPTION
Fix resource visited button state..
Before:
![current](https://user-images.githubusercontent.com/8450357/27398637-06746f6a-5680-11e7-93f0-f038ed070483.png)

After:
![change-goes-back-towhat_it_was](https://user-images.githubusercontent.com/8450357/27398648-0cbb873c-5680-11e7-8b0d-3f27374a15aa.png)
