### PR TITLE
style(derek): Placing resource teaser links in consistent location

### DIFF
--- a/styleguide/derek/pattern-components/resourceCenter-resource/_resourceCenter-resource.scss
+++ b/styleguide/derek/pattern-components/resourceCenter-resource/_resourceCenter-resource.scss
@@ -58,10 +58,13 @@
 .resource-descWrapper {
   @include make-xs-column(12);
   margin-top: 15px;
+  padding-bottom: 25px;
 }
 
 .resource-linkWrapper {
-  @include make-xs-column(12);
+  bottom: 5px;
+  padding: 0 25px 10px;
+  position: absolute;
 }
 
 .resource-link {


### PR DESCRIPTION
RSWEB-9321

Adjusting the resource teaser link to sit at the bottom of the wrapper consistently.
Visible here:
http://localhost:3000/derek/view-templates/resource-center/resource-center