### PR TITLE
feat(slteaser): adding special case for non/linked cards

### DIFF
--- a/styleguide/derek/pattern-components/service-level-teaser/_partials/teaser-link.ejs
+++ b/styleguide/derek/pattern-components/service-level-teaser/_partials/teaser-link.ejs
@@ -15,7 +15,7 @@
   var standoutClass = "";
 } %>
 <!-- Service Level Teaser Pattern -->
-<div class="serviceLevelTeaser <%- standoutClass %>" href="javascript:void(0)">
+<a class="serviceLevelTeaser serviceLevelTeaser-link <%- standoutClass %>" href="javascript:void(0)">
   <div class="serviceLevelTeaser-row">
     <div class="serviceLevelTeaser-col-full">
       <h2 class="serviceLevelTeaser-header"><%- title %></h2>
@@ -24,4 +24,4 @@
       <p class="serviceLevelTeaser-body"><%- desc %></p>
     </div>
   </div>
-</div>
+</a>

--- a/styleguide/derek/pattern-components/service-level-teaser/_service-level-teaser.scss
+++ b/styleguide/derek/pattern-components/service-level-teaser/_service-level-teaser.scss
@@ -9,6 +9,10 @@
   position: relative;
   text-decoration: none;
   width: 100%;
+}
+
+// only add a hover class if a link
+.serviceLevelTeaser-link {
 
   &:hover {
     background-color: $gray-lightest;

--- a/styleguide/derek/pattern-components/service-level-teaser/service-level-teaser.ejs
+++ b/styleguide/derek/pattern-components/service-level-teaser/service-level-teaser.ejs
@@ -1,5 +1,5 @@
 <div class=" half-padding container">
-  <h3>Service Level Teasers (default)</h3>
+  <h3>Service Level Teasers (default w/links)</h3>
 </div>
 
 <!-- Service Level Teaser -->
@@ -7,21 +7,21 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
+        <%- partial('_partials/teaser-link.ejs', {
           title: "Human Experts",
           icon: "idio-winner",
           price: "$500/m"
         }) %>
       </div>
       <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
+        <%- partial('_partials/teaser-link.ejs', {
           title: "Navigator",
           icon: "srv-navigator",
           price: "$600/m"
         }) %>
       </div>
       <div class="col-sm-4">
-        <%- partial('_partials/teaser.ejs', {
+        <%- partial('_partials/teaser-link.ejs', {
           title: "Aviator",
           icon: "srv-aviator",
           price: "$700/m"
@@ -35,7 +35,7 @@
 </div>
 
 <div class="half-padding container">
-  <h3>Service Level Teasers 2 only (default)</h3>
+  <h3>Service Level Teasers 2 only (default no links)</h3>
 </div>
 
 <!-- Teaser with only 2 option -->
@@ -64,7 +64,7 @@
 </div>
 
 <div class="half-padding container">
-  <h3>Service Level Teasers (stand out option)</h3>
+  <h3>Service Level Teasers (stand out option no links)</h3>
 </div>
 <!-- Teaser with a standout option -->
 <div class="half-padding">


### PR DESCRIPTION

<img width="1038" alt="screen shot 2017-08-30 at 1 20 17 pm" src="https://user-images.githubusercontent.com/4554644/29888302-152184c0-8d86-11e7-8571-407a5d241c60.png">
See new pattern changes here:

service level teaser (3 up) shows link example,
the others are not linked

http://rsweb-9592-add-nonlink-slteasers.styleguide.dev.website.rackspace.com/derek/incubation/solutions