### PR TITLE
bug(derek): tab container full width

### DIFF
--- a/styleguide/derek/pattern-components/tabs/_tabs.scss
+++ b/styleguide/derek/pattern-components/tabs/_tabs.scss
@@ -82,7 +82,8 @@
 
 // Overrides for the tabCollapse plugin & bootstrap panel classes
 .rsTabs-container {
-  padding: $half-padding-full;
+  @include make-container;
+  padding: $half-padding-top;
 
   .panel {
     @include border-radius(0);
@@ -152,8 +153,6 @@
     margin: 0 auto 10px;
     max-width: $screen-lg-min;
     padding-bottom: 0;
-    padding-left: 0;
-    padding-right: 0;
   }
 
   .rsTabsHorizontal-tab {


### PR DESCRIPTION
RSWEB-9343

Addition of the actual container mixin to the tab container class. Won't need any www work.
Both types of tabs can be seen here:
http://localhost:3000/derek/patterns/patterns

The tabs can also be seen as they would appear in the page here:
http://localhost:3000/derek/templates/content-driven/industry

Would still like to see a screen capture on staging to make sure there isn't something in Drupal that effects the containers. Or if any of the EBPs have been putting the tabs in container classes or rivers. If there is a mix then we may have a content issue we'll need to fix.