### PR TITLE
RSWEB-9665: Fix google plus social button

### DIFF
--- a/styleguide/derek/global-components/social/_social.scss
+++ b/styleguide/derek/global-components/social/_social.scss
@@ -3,6 +3,15 @@
   top: -8px;
 }
 
+.social-button {
+  display: inline-block;
+  margin: 0 2px;
+}
+
+.social-googleplusWrapper {
+  width: 57px;
+}
+
 .social-shareEmail {
   background-color: $gray-base;
   border-radius: 3px;

--- a/styleguide/derek/global-components/social/social.ejs
+++ b/styleguide/derek/global-components/social/social.ejs
@@ -18,8 +18,18 @@
 <script src="https://apis.google.com/js/platform.js" async defer></script>
 
 <!-- Button Codes -->
-<script type="IN/Share" data-url="rackspace.com"></script>
-<div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse">Share</a></div>
-<a href="https://twitter.com/intent/tweet?text=Checkout this resource from @Rackspace" class="twitter-share-button" data-show-count="false">Tweet</a>
-<div class="g-plus" data-action="share"></div>
-<a class="social-shareEmail" href="mailto:?subject=Checkout this great resource from Rackspace&body=I found this great resource from Rackspace. http://www.rackspace.com" >Email</a>
+<div class="social-button social-linkedinWrapper">
+  <script type="IN/Share" data-url="rackspace.com"></script>
+</div>
+<div class="social-button social-facebookWrapper">
+  <div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse">Share</a></div>
+</div>
+<div class="social-button social-twitterWrapper">
+  <a href="https://twitter.com/intent/tweet?text=Checkout this resource from @Rackspace" class="twitter-share-button" data-show-count="false">Tweet</a>
+</div>
+<div class="social-button social-googleplusWrapper">
+  <div class="g-plus" data-action="share"></div>
+</div>
+<div class="social-button social-emailWrapper">
+  <a class="social-shareEmail" href="mailto:?subject=Checkout this great resource from Rackspace&body=I found this great resource from Rackspace. http://www.rackspace.com" >Email</a>
+</div>


### PR DESCRIPTION
This PR fixes an issue with google plus button adding more width then necessary with inline styles dynamically in safari. 

Unfortunately, there is not class added to the dynamically created button. So I had to disable a couple of rules, only for the social.scss file.