### PR TITLE
RSWEB-9528: Fix callout form

### DIFF
--- a/styleguide/_themes/global/scss/forms.scss
+++ b/styleguide/_themes/global/scss/forms.scss
@@ -205,6 +205,18 @@ table {
   }
 }
 
+.calloutForm {
+  max-width: 100%;
+
+  .form-label {
+    font-size: 1.2rem;
+  }
+
+  .form-submit {
+    width: 100%;
+  }
+}
+
 @media (min-width: $screen-sm-min) {
   .formModal-dialog {
     width: 440px;

--- a/styleguide/derek/pattern-components/lp-callout/_lp-callout.scss
+++ b/styleguide/derek/pattern-components/lp-callout/_lp-callout.scss
@@ -37,18 +37,6 @@
   text-align: center;
 }
 
-.calloutForm-label {
-  font-size: 1.2rem;
-}
-
-.calloutForm-captcha {
-  margin: 10px 0;
-}
-
-.calloutForm-button {
-  width: $full-width;
-}
-
 @media only screen and (min-width: $screen-sm-max) {
   .lp-callout-form {
     margin-top: 0;

--- a/styleguide/derek/pattern-components/lp-callout/_partials/lp-callout-form.ejs
+++ b/styleguide/derek/pattern-components/lp-callout/_partials/lp-callout-form.ejs
@@ -1,25 +1,27 @@
 <div class="calloutForm">
   <form>
     <div class="form-group">
-      <label for="firstName" class="calloutForm-label">First Name</label>
+      <label for="firstName" class="form-label">First Name</label>
       <input type="name" class="form-control" id="firstName">
     </div>
     <div class="form-group">
-      <label for="lastName" class="calloutForm-label">Last Name</label>
+      <label for="lastName" class="form-label">Last Name</label>
       <input type="name" class="form-control" id="lastName">
     </div>
     <div class="form-group">
-      <label for="email" class="calloutForm-label">Email address</label>
+      <label for="email" class="form-label">Email address</label>
       <input type="email" class="form-control" id="email">
     </div>
     <div class="form-group">
-      <label for="phone" class="calloutForm-label">Phone Number</label>
+      <label for="phone" class="form-label">Phone Number</label>
       <input type="phone" class="form-control" id="phone">
     </div>
-  <button type="submit" class="button lead calloutForm-button">Send</button>
-  <div class="calloutForm-captcha">
-    <img src="/imgs/derek/captcha.jpg" style="max-width: none; width: 304px; height: 78px;">
-  </div>
-  <p class="copyright">Information collected in this form is subject to the <a href="#">Rackspace Privacy Statement.</a></p>
+
+    <img src="/imgs/derek/captcha.jpg" style="max-width: none; width: 304px; height: 78px; margin: 10px 0;">
+
+    <div class="form-actions">
+      <button type="submit" class="button lead form-submit">Send</button>
+    </div>
+    <p class="small half-padding-top">Information collected in this form is subject to the <a href="#">Rackspace Privacy Statement.</a></p>
   </form>
 </div>


### PR DESCRIPTION
This PR moves some of the maintainable callout form css out into css inside of `.calloutForm`.  This is due to a weird drupalism, where we don't have full context of where a form lives and which build mode it uses without doing some weird hacks to core. 