### PR TITLE
fix(resource): fix floating icon with resource in panel

### DIFF
--- a/styleguide/derek/pattern-components/resourceCenter-resource/refresh/_resourceCenter-resource.scss
+++ b/styleguide/derek/pattern-components/resourceCenter-resource/refresh/_resourceCenter-resource.scss
@@ -19,6 +19,7 @@
   grid-template-rows: .25fr auto .25fr;
   height: 175px;
   overflow: hidden;
+  position: relative;
 }
 
 .resource-bottom {


### PR DESCRIPTION
Bug fix for floating icon:
Page: https://www.rackspace.com/managed-aws/competencies
Issue:
<img width="1277" alt="rackspace_aws_competencies" src="https://user-images.githubusercontent.com/8450357/32668705-ef39d1a2-c603-11e7-91a0-6d315d010719.png">

http://rsweb-10004-fix-floating-icon.zoolander.dev.website.rackspace.com/managed-aws/competencies