### PR TITLE
style(pagination): styling Drupal markup classes for pagination

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,6 +4,7 @@ files:
     - 'styleguide/_themes/global/scss/rsweb-font-style.scss'
     - 'styleguide/_sass/syntax-highlighting.scss'
     - 'styleguide/_themes/derek/scss/components/rsweb-font-style.scss'
+    - 'styleguide/_themes/derek/scss/components/pager.scss'
     - 'styleguide/_themes/global/scss/bootstrap_variables.scss'
     - 'styleguide/_themes/global/scss/bootstrap_overrides.scss'
     - 'styleguide/_themes/global/scss/vendor_prefixes.scss'

--- a/styleguide/_themes/derek/scss/components/pager.scss
+++ b/styleguide/_themes/derek/scss/components/pager.scss
@@ -19,3 +19,46 @@
   display: inline;
   padding: .25rem;
 }
+
+.pager__items {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 40px 10px 20px;
+}
+
+.pager__item {
+  color: $pager-text;
+  float: left;
+  font-size: 12px;
+  margin-right: 10px;
+}
+
+.pager__item:last-child {
+  margin-right: 0;
+}
+
+.pager__item a {
+  border: 1px solid $pager-text;
+  color: $pager-text;
+  display: block;
+  padding: 3px 8px;
+}
+
+.pager__item a:focus {
+  text-decoration: none;
+}
+
+.pager__item a:hover {
+  background-color: $pager-bg;
+  color: $white;
+  text-decoration: none;
+  transition-duration: .2s;
+}
+
+.pager__item.is-active a {
+  background-color: $pager-bg;
+  color: $white;
+}

--- a/styleguide/_themes/global/scss/swatch.scss
+++ b/styleguide/_themes/global/scss/swatch.scss
@@ -51,3 +51,7 @@ $filterbar-gray:   #404449;
 $stories-link-gray: fade-out($white, .3);
 $stories-img-gray: fade-out($white, .7);
 $stories-paginate-gray: fade-out($white, .9);
+
+// pagination
+$pager-text: #929292;
+$pager-bg: rgba($black, .5);

--- a/styleguide/derek/view-templates/events/events.ejs
+++ b/styleguide/derek/view-templates/events/events.ejs
@@ -40,14 +40,7 @@
             </div>
           <% } %>
         <% } %>
-        <ul class="eventsOverview-pagination">
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPagePrev" href="javascript:void(0)">&lt;</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">1</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageActive" href="javascript:void(0)">2</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">3</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage" href="javascript:void(0)">4</a></li>
-          <li class="eventsOverview-pagination-item"><a class="eventsOverview-pagination-itemPage eventsOverview-pagination-itemPageNext" href="javascript:void(0)">&gt;</a></li>
-        </ul>
+        <%- partial('../pagination.ejs') %>
       </div>
     </div>
   </div>

--- a/styleguide/derek/view-templates/pagination.ejs
+++ b/styleguide/derek/view-templates/pagination.ejs
@@ -1,0 +1,50 @@
+<nav class="pager" role="navigation" aria-labelledby="pagination-heading">
+  <h4 id="pagination-heading" class="hidden"></h4>
+  <ul class="pager__items js-pager__items">
+      <li class="pager__item pager__item--first">
+        <a href="javascript:void(0)" title="Go to first page">
+          <span class="hidden"></span>
+          <span aria-hidden="true">« 
+            <span class="hidden-sm hidden-xs">First</span>
+          </span>
+        </a>
+      </li>
+      <li class="pager__item pager__item--previous">
+        <a href="javascript:void(0)" title="Go to previous page" rel="prev">
+          <span class="hidden"></span>
+          <span aria-hidden="true">‹‹ 
+            <span class="hidden-sm hidden-xs">Back</span>
+          </span>
+        </a>
+      </li>
+      <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
+      <li class="pager__item is-active"><a href="javascript:void(0)" title="Current page"><span class="hidden"></span>1</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 2"><span class="hidden">Page </span>2</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 3"><span class="hidden"></span>3</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 4"><span class="hidden"></span>4</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 5"><span class="hidden"></span>5</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 6"><span class="hidden"></span>6</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 7"><span class="hidden"></span>7</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 8"><span class="hidden"></span>8</a></li>
+      <li class="pager__item"><a href="javascript:void(0)" title="Go to page 9"><span class="hidden"></span>9</a></li>
+      <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
+      <li class="pager__item pager__item--next">
+        <a href="javascript:void(0)" title="Go to next page" rel="next">
+          <span class="hidden"></span>
+          <span aria-hidden="true">
+            <span class="hidden-sm hidden-xs">Next</span> 
+            ››
+          </span>
+        </a>
+      </li>
+      <li class="pager__item pager__item--last">
+        <a href="javascript:void(0)" title="Go to last page">
+          <span class="hidden"></span>
+          <span aria-hidden="true">
+            <span class="hidden-sm hidden-xs">Last</span> 
+            »
+          </span>
+        </a>
+      </li>
+  </ul>
+</nav>

--- a/styleguide/derek/view-templates/resource-center/resource-center.ejs
+++ b/styleguide/derek/view-templates/resource-center/resource-center.ejs
@@ -189,6 +189,7 @@
       <div class="resourcecenter-resourceRow">
         <%- partial('../../pattern-components/resourceCenter-resource/resourceCenter-resourcesNoContainer.ejs') %>
       </div>
+        <%- partial('../pagination.ejs') %>
     </div>
   </div>
 </div>

--- a/styleguide/derek/view-templates/stories/stories.ejs
+++ b/styleguide/derek/view-templates/stories/stories.ejs
@@ -109,15 +109,7 @@ var featQuotes = [
           <% } %>
         </div>
         <% } %>
-        <div class="row">
-          <div class="rsFilter-storiesPager">
-            <ul class="pager">
-              <li class="pager-previous first"><a href="javascript:void(0);">prev</a></li>
-              <li class="pager-current">2 of 10</li>
-              <li class="pager-next last"><a href="javascript:void(0);">next</a></li>
-            </ul>
-          </div>
-        </div>
+        <%- partial('../pagination.ejs') %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Since we're now using the default Drupal pagination markup, this PR adds in styling for it into Zoolander.

Events: http://rsweb-10124-pagerstyleclasses.styleguide.dev.website.rackspace.com/derek/view-templates/events/events

Stories: http://rsweb-10124-pagerstyleclasses.styleguide.dev.website.rackspace.com/derek/view-templates/stories/stories

Resources: http://rsweb-10124-pagerstyleclasses.styleguide.dev.website.rackspace.com/derek/view-templates/resource-center/resource-center

