### PR TITLE
MTE-921: Move zoolander-only JS out of global.js

### DIFF
--- a/styleguide/_layouts/default.jade
+++ b/styleguide/_layouts/default.jade
@@ -94,6 +94,7 @@ html(lang="en")
       block content
 
   script(src="#{base}js/global.js")
+  script(src="#{base}js/zoolander-only.js")
   script(src="#{base}global/modal.js")
   script.
     $(".imacBanner-headline").fitText(1.1, { maxFontSize: '45px' });

--- a/styleguide/global/global.js
+++ b/styleguide/global/global.js
@@ -60,36 +60,6 @@ jQuery(document).ready(($) => {
   // initialize the responsive tables
   $('.productTable').responsiveTable();
 
-  // tooltip
-  $('[data-toggle="tooltip"]').tooltip();
-
-  // dropdowns
-  $('.navZoolander-hasDropdown').unbind().click((e) => {
-    e.preventDefault();
-    const $el = jQuery(e.currentTarget);
-    $el.next('.navZoolander-dropdown').slideToggle(200);
-    $el.toggleClass('hasDropDown-active');
-  });
-
-  // Slide toggle the zoolander nav
-  const zoolanderSlideBtn = $('.navZoolander-slideBtn');
-  zoolanderSlideBtn.unbind().click((e) => {
-    e.preventDefault();
-    const $me = $(e.currentTarget);
-    $me.toggleClass('navZoolander-slideBtn-collapsed');
-    $me.next('.navZoolander-container').toggleClass('navZoolander-container-collapsed');
-    $('.mainContainer').toggleClass('mainContainer-collapsed');
-  });
-
-  // Zoolander only solution for auto collapsing menu on example pages
-  const url = window.location.pathname;
-  if ((url.match(/\/derek\/incubation\//gi) && url !== '/derek/incubation/') ||
-      (url.match(/\/derek\/view-templates\//gi) && url !== '/derek/view-templates/') ||
-      (url.match(/\/derek\/solutions\//gi) && url !== '/derek/solutions/') ||
-      (url.match(/\/derek\/templates\//gi) && url !== '/derek/templates/')) {
-    zoolanderSlideBtn.trigger('click');
-  }
-
   // search
   const searchContainer = $('#navbar-search');
   const searchSubmit = searchContainer.find('.navbar-icon-search');

--- a/styleguide/global/zoolander-only.js
+++ b/styleguide/global/zoolander-only.js
@@ -1,0 +1,32 @@
+
+(($) => {
+  // tooltip
+  $('[data-toggle="tooltip"]').tooltip();
+
+  // dropdowns
+  $('.navZoolander-hasDropdown').unbind().click((e) => {
+    e.preventDefault();
+    const $el = jQuery(e.currentTarget);
+    $el.next('.navZoolander-dropdown').slideToggle(200);
+    $el.toggleClass('hasDropDown-active');
+  });
+
+  // Slide toggle the zoolander nav
+  const zoolanderSlideBtn = $('.navZoolander-slideBtn');
+  zoolanderSlideBtn.unbind().click((e) => {
+    e.preventDefault();
+    const $me = $(e.currentTarget);
+    $me.toggleClass('navZoolander-slideBtn-collapsed');
+    $me.next('.navZoolander-container').toggleClass('navZoolander-container-collapsed');
+    $('.mainContainer').toggleClass('mainContainer-collapsed');
+  });
+
+  // Zoolander only solution for auto collapsing menu on example pages
+  const url = window.location.pathname;
+  if ((url.match(/\/derek\/incubation\//gi) && url !== '/derek/incubation/') ||
+      (url.match(/\/derek\/view-templates\//gi) && url !== '/derek/view-templates/') ||
+      (url.match(/\/derek\/solutions\//gi) && url !== '/derek/solutions/') ||
+      (url.match(/\/derek\/templates\//gi) && url !== '/derek/templates/')) {
+    zoolanderSlideBtn.trigger('click');
+  }
+})(jQuery);


### PR DESCRIPTION
This PR moves zoolander-only javascript out of the global.js file.  This is necessary for D8 based on how we're pulling in global.js