### PR TITLE
fix(zindex): Chat is appearing under the navbar in mobile..

### DIFF
--- a/styleguide/_themes/global/scss/bootstrap_variables.scss
+++ b/styleguide/_themes/global/scss/bootstrap_variables.scss
@@ -298,7 +298,7 @@ $zindex-navbar:            1000 !default;
 $zindex-dropdown:          1000 !default;
 $zindex-popover:           1060 !default;
 $zindex-tooltip:           1070 !default;
-$zindex-navbar-fixed:      1030 !default;
+$zindex-navbar-fixed:       950 !default;
 $zindex-modal-background:  1040 !default;
 $zindex-modal:             1050 !default;
 


### PR DESCRIPTION
It is with a heavy heart that I dare alter the zindex variable. The chat modal is losing the battle and is appearing under the navbar due to its puny 999 value. 
Chat:
![chat_modal_](https://user-images.githubusercontent.com/8450357/46367401-0f80ae00-c643-11e8-969f-01b1691cf1df.png)
Nav:
![rs_nav_](https://user-images.githubusercontent.com/8450357/46367492-59699400-c643-11e8-98a0-98a3aa8b0664.png)


