### PR TITLE
MTE-1503: Adds a Languages Spoken for Event content.

### DIFF
--- a/dist/derek/view-templates/events/events-interior.html
+++ b/dist/derek/view-templates/events/events-interior.html
@@ -334,6 +334,13 @@ function svgBannerSetContent(primaryBox = 25) {
               8:00am-6:00pm
             </div>
           </div>
+          <div class="event-info-spoken">
+            <div class="event-info-spokenTitle">Languages Spoken</div>
+            <div class="event-info-spokenList">
+              <p>Dutch</p>
+              <p>English</p>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/styleguide/derek/view-templates/events/_events.scss
+++ b/styleguide/derek/view-templates/events/_events.scss
@@ -233,7 +233,8 @@
 
 .event-detailsTitle,
 .event-info-whereTitle,
-.event-info-whenTitle {
+.event-info-whenTitle,
+.event-info-spokenTitle {
   @include subhead;
 }
 
@@ -275,13 +276,21 @@
 }
 
 .event-info-where {
-  @include make-sm-column(5);
+  @include make-sm-column(4);
   margin-bottom: 1rem;
 }
 
 .event-info-when {
-  @include make-sm-column(5);
+  @include make-sm-column(4);
   margin-bottom: 1rem;
+}
+
+.event-info-spoken {
+  @include make-sm-column(4);
+  margin-bottom: 1rem;
+  p {
+    margin: 0;
+  }
 }
 
 .event-map {
@@ -450,6 +459,10 @@
 
   .event-info-when {
     padding-left: .6rem;
+  }
+
+  .event-info-spoken {
+    padding: $no-padding;
   }
 
   .event-map {

--- a/styleguide/derek/view-templates/events/events-interior.ejs
+++ b/styleguide/derek/view-templates/events/events-interior.ejs
@@ -37,6 +37,13 @@
               8:00am-6:00pm
             </div>
           </div>
+          <div class="event-info-spoken">
+            <div class="event-info-spokenTitle">Languages Spoken</div>
+            <div class="event-info-spokenList">
+              <p>Dutch</p>
+              <p>English</p>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://jira.rax.io/browse/MTE-1503

_I HAVE NO IDEA WHAT I'M DOING_

<img width="1173" alt="screenshot 2019-02-19 at 17 47 16" src="https://user-images.githubusercontent.com/1250035/53038205-11250400-3474-11e9-804e-bdd9f6630e9f.png">

Adds "Languages Spoken" styling.  Has no graceful fallback for when the field isn't populated ...