### PR TITLE
fix(margins): lining up margins on interior events page

### DIFF
--- a/styleguide/derek/view-templates/events/_events.scss
+++ b/styleguide/derek/view-templates/events/_events.scss
@@ -294,11 +294,6 @@
   width: 100%;
 }
 
-.event-row {
-  @include make-row;
-}
-
-
 .event-speaker-section {
   padding: 20px 0;
 }


### PR DESCRIPTION
This PR will line up the content margins for the event interior content to the rest of the page.