### PR TITLE
MTE-3870: Home Page SVG Very Small on IE and FF (Windows)

### DIFF
--- a/styleguide/derek/pattern-components/about-river/_about-river.scss
+++ b/styleguide/derek/pattern-components/about-river/_about-river.scss
@@ -55,3 +55,10 @@
     padding-top: 25px;
   }
 }
+
+// IE 10 + hack here
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .overlap-circ-fill {
+    height: 310px;
+  }
+}


### PR DESCRIPTION
https://jira.rax.io/browse/MTE-3870

Put in a change that applies to IE only.