### PR TITLE
fix(nav): adding toggle for off hover on dropdown triggers

### DIFF
--- a/styleguide/derek/global-components/mainnav/mainnav.js
+++ b/styleguide/derek/global-components/mainnav/mainnav.js
@@ -82,6 +82,10 @@ $('.navbar-tertiary-dropDownTrigger')
       checkSubMenuView($(e.currentTarget).find('> .navbar-dropDownMenu'));
     }
   }, (e) => {
+    if ($viewPort > 768) {
+      // toggle open dropdowns
+      dropDownTrigger($(e.currentTarget));
+    }
     // reset the custom top value
     $(e.currentTarget).find('> .navbar-dropDownMenu').css('top', '');
   });


### PR DESCRIPTION
This PR fixes the nav issues where the drop down triggers were not hiding submenu's when hovering off of them.
![nav-hover-fix](https://user-images.githubusercontent.com/4554644/54774449-c107a180-4bd9-11e9-8f3b-7a97da586301.gif)
