### PR TITLE
fix(buy-now): Resize button for translations

### DIFF
--- a/styleguide/derek/global-components/modal/_buy-now.scss
+++ b/styleguide/derek/global-components/modal/_buy-now.scss
@@ -24,9 +24,9 @@
 
 .buyNow-cardButton {
   bottom: $grid-gutter-width / 4;
-  margin-left: -75px;
+  margin-left: -90px;
   position: absolute;
-  width: 150px;
+  width: 180px;
 }
 
 .buyNow-chat {


### PR DESCRIPTION
This PR fixes an issue with translations on the "Buy Now" buttons. 

Before:
![image](https://user-images.githubusercontent.com/5263371/57311177-c39e5780-70b0-11e9-91cc-135702ca5013.png)

After:
![image](https://user-images.githubusercontent.com/5263371/57311232-db75db80-70b0-11e9-9a82-d4dbdf112b17.png)
