### PR TITLE
MTE-4365: Use alt tags on track-cta click w/ images

### DIFF
--- a/styleguide/derek/global-components/tracking/tracking.js
+++ b/styleguide/derek/global-components/tracking/tracking.js
@@ -176,7 +176,7 @@ Zoolander.Tracking = (function Tracking($) {
         event: 'cta.click',
         eventCategory: 'CTA',
         eventAction: 'CTA Click',
-        eventLabel: $(e.target).text() || $(e.target).find('img').attr('alt') || 'undefined',
+        eventLabel: $(e.target).text() || $(e.currentTarget).find('img').prop('alt') || 'undefined',
         eventValue: '0',
         eventNonInteraction: 0,
       });

--- a/styleguide/derek/global-components/tracking/tracking.spec.js
+++ b/styleguide/derek/global-components/tracking/tracking.spec.js
@@ -327,11 +327,22 @@ describe('Zoolander Tracking Module', () => {
     });
 
     it('should track image links', () => {
-      $('body').append('<a class="track-cta" href="https://rackspace.com"><img src="#" alt="My Alt Text"></a>');
+      $('body').append('<a class="track-cta" href="#"><img class="my-img" src="#" alt="My Alt Text"></a>');
       Zoolander.Tracking.init();
 
       $('.track-cta').trigger('click');
-      const expected = {
+      let expected = {
+        event: 'cta.click',
+        eventCategory: 'CTA',
+        eventAction: 'CTA Click',
+        eventLabel: 'My Alt Text',
+        eventValue: '0',
+        eventNonInteraction: 0,
+      };
+      expect(expected).to.eql(window.dataLayer.pop());
+
+      $('.my-img').trigger('click');
+      expected = {
         event: 'cta.click',
         eventCategory: 'CTA',
         eventAction: 'CTA Click',


### PR DESCRIPTION
This PR fixes an issue where cta tracking didn't work properly with alt tags. 