### PR TITLE
fix(german): Fix icon padding for german

### DIFF
--- a/styleguide/derek/global-components/modal/_buy-now.scss
+++ b/styleguide/derek/global-components/modal/_buy-now.scss
@@ -81,7 +81,7 @@
     margin: inherit;
     max-width: none;
     padding-left: 0;
-    padding-right: 25px;
+    padding-right: 50px;
     padding-top: 10px;
   }
 

--- a/styleguide/derek/pattern-components/page-banner/_page-banner.scss
+++ b/styleguide/derek/pattern-components/page-banner/_page-banner.scss
@@ -290,7 +290,7 @@
     margin-bottom: 0;
     margin-left: 0;
     max-width: 250px;
-    padding-right: 40px;
+    padding-right: 50px;
     position: relative;
     text-align: left;
 


### PR DESCRIPTION
This PR fixes a padding issue with German

Before:
- ![image](https://user-images.githubusercontent.com/5263371/57345678-540c8480-7111-11e9-8433-fd4e95e4bcf5.png)
- ![image](https://user-images.githubusercontent.com/5263371/57345674-51aa2a80-7111-11e9-950e-dffa8f0991c2.png)

After
