### PR TITLE
MTE 3807 Adding a fix for install bug

### DIFF
--- a/scripts/install-modules.sh
+++ b/scripts/install-modules.sh
@@ -4,7 +4,15 @@
 set -e
 
 # add fonts
-cp -rf node_modules/mozilla-fira-pack/Fira styleguide/font/
+if [ ! -d ./node_modules/mozilla-fira-pack ]; then
+  npm install --save mozilla-fira-pack
+fi
+
+cp -rf ./node_modules/mozilla-fira-pack/Fira styleguide/font/
 
 # add scroll reveal
-cp node_modules/scrollreveal/dist/scrollreveal.min.js styleguide/global/plugins/scrollreveal.min.js
+if [ ! -d ./node_modules/scrollreveal ]; then
+  npm install --save scrollreveal
+fi
+
+cp ./node_modules/scrollreveal/dist/scrollreveal.min.js styleguide/global/plugins/scrollreveal.min.js


### PR DESCRIPTION
Trying to install zoolander 2.0.x as a dependency ie (```npm install git://github.com/rackerlabs/zoolander.git#2.0.x --save```) kept erroring on the zoolander postinstall script:

```bash
> ./scripts/install-modules.sh

cp: ./node_modules/mozilla-fira-pack/Fira: No such file or directory
```
This only happens when installing zoolander as a dependency and not inside the repo itself. After investigating it looked like a race condition where all of zoolanders dependencies were not available inside `node_modules` folder when the ```postinstall``` script ran.

Adding a check for the directory allowed the install to run successfully.