### PR TITLE
fix(tables): fix for plugin adding multiple headers for mobile tables

### DIFF
--- a/styleguide/global/global.js
+++ b/styleguide/global/global.js
@@ -22,8 +22,12 @@ jQuery(document).ready(($) => {
       const $cellTitle = $el.find('.productTable-name');
       // place table head titles into each cell as labels
       $el.find('tbody tr td').each(function responsiveTableTdEach() {
-        const $index = $(this).index();
-        $(this).prepend(`<strong class="productTable-mobileTitle">${$cellTitle.eq($index).html()}</strong>`);
+        const $td = $(this);
+        const $mobileTitle = $td.find('.productTable-mobileTitle');
+        if ($mobileTitle.length < 1) {
+          const $index = $td.index();
+          $(this).prepend(`<strong class="productTable-mobileTitle">${$cellTitle.eq($index).html()}</strong>`);
+        }
       });
     });
     // allow this plugin to be chainable via jQuery


### PR DESCRIPTION
Table plugin now checks if the mobile title is already there before it tries to add it.