### PR TITLE
research(fonts): removing some fira sans types in the name of research

### DIFF
--- a/styleguide/_themes/global/scss/fira-font-style.scss
+++ b/styleguide/_themes/global/scss/fira-font-style.scss
@@ -12,6 +12,4 @@
   }
 }
 
-@include loadFiraWeight('FiraSans-ExtraLight', 200);
 @include loadFiraWeight('FiraSans-Light', 300);
-@include loadFiraWeight('FiraSans-Regular', 400);

--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -22,7 +22,7 @@ $standard-line-height: 20px;
 @mixin subhead($color: $gray-darkest) {
   color: $color;
   font-family: $subhead;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: .05em;
   line-height: 1.45em;
   text-align: left;

--- a/styleguide/derek/global-components/modal/_buy-now.scss
+++ b/styleguide/derek/global-components/modal/_buy-now.scss
@@ -21,7 +21,7 @@
 
 .buyNow-cardPrice {
   display: none;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .buyNow-cardButton {

--- a/styleguide/derek/pattern-components/o365-table/_o365-table.scss
+++ b/styleguide/derek/pattern-components/o365-table/_o365-table.scss
@@ -58,7 +58,7 @@ $table-border: 1px solid $gray-lighter;
   border: $table-border;
   border-spacing: 0;
   font-family: $subhead;
-  font-weight: 500;
+  font-weight: 600;
   padding: 35px 20px;
   text-align: center;
   width: 20%;

--- a/styleguide/derek/view-templates/events/_events.scss
+++ b/styleguide/derek/view-templates/events/_events.scss
@@ -269,7 +269,7 @@
   border-bottom: 1px solid $gray-lightest;
   display: block;
   font-size: 20px;
-  font-weight: 500;
+  font-weight: 600;
   padding: 15px 0;
   position: relative;
   text-align: center;
@@ -317,7 +317,7 @@
   border-right: 2px solid $rackspace-red;
   color: $havas-blue-gray;
   font-size: 17px;
-  font-weight: 500;
+  font-weight: 600;
   width: 15%;
 }
 

--- a/styleguide/derek/view-templates/resource-center/_resource-center.scss
+++ b/styleguide/derek/view-templates/resource-center/_resource-center.scss
@@ -179,7 +179,7 @@
 
 .resourcecenter-featuredTextLink {
   color: $white;
-  font-weight: 500;
+  font-weight: 600;
 
   &:hover {
     color: $white;


### PR DESCRIPTION
For research I removed all versions of Fira Sans and kept the most widely used one 'Fira-Sans-Light' and updated patterns using 500 font-weight to 600 to try and get the same effect. Other patterns trying to be bolder than that won't be able to.