### PR TITLE
MTE-5223: Resolve linkedin tracking issue

### DIFF
--- a/styleguide/derek/global-components/social/_social.scss
+++ b/styleguide/derek/global-components/social/_social.scss
@@ -19,7 +19,6 @@ $xing-green: #005a5f;
   padding: 0 0 0 2px;
   position: relative;
   text-decoration: none;
-  top: -1px;
   vertical-align: top;
   white-space: nowrap;
 
@@ -33,14 +32,13 @@ $xing-green: #005a5f;
 }
 
 .fb-share-icon {
-  background-image: url('https://static-dft4-3.xx.fbcdn.net/rsrc.php/v3/yP/r/Wq8eKb91kes.png');
-  background-size: contain;
-  display: inline-block;
-  height: 16px;
-  margin-right: 1px;
-  position: relative;
-  top: 1px;
-  width: 16px;
+  color: $white;
+  font-family: 'rswebfonts';
+  font-size: 16px;
+
+  &::before {
+    content: '\f09a';
+  }
 }
 
 .fb-share-text {
@@ -124,5 +122,14 @@ $xing-green: #005a5f;
 
   &:hover {
     color: $linkedin-darkblue;
+  }
+}
+
+// Hacky fix for social button alignment.
+.twitter-share-button {
+  &[style] {
+    // sass-lint:disable-block no-important
+    position: relative !important;
+    top: 5px;
   }
 }

--- a/styleguide/derek/global-components/social/social-tracking.js
+++ b/styleguide/derek/global-components/social/social-tracking.js
@@ -34,15 +34,30 @@ Zoolander.SocialTracking = (() => {
   }
 
   function LinkedInTracking() {
-    const button = document.getElementsByClassName('IN-widget')[0];
-    button.addEventListener('click', (e) => {
-      dataLayer.push({
-        event: 'social.click',
-        socialNetwork: 'LinkedIn',
-        socialAction: 'share',
-        socialTarget: e.view.location.href,
-      });
-    });
+    const intervalTime = 100;
+    const maxAttempts = 3;
+    let runCt = 0;
+
+    // Hacky method to wait until IN-widget has been declared since no proper events exist.
+    const myInterval = setInterval(() => {
+      const button = document.getElementsByClassName('IN-widget')[0];
+      if (typeof button !== 'undefined') {
+        clearInterval(myInterval);
+        button.addEventListener('click', (e) => {
+          dataLayer.push({
+            event: 'social.click',
+            socialNetwork: 'LinkedIn',
+            socialAction: 'share',
+            socialTarget: e.view.location.href,
+          });
+        });
+      } else {
+        runCt += 1;
+        if (runCt > maxAttempts) {
+          clearInterval(myInterval);
+        }
+      }
+    }, intervalTime);
   }
 
   function EmailTracking() {

--- a/styleguide/derek/global-components/social/social-tracking.js
+++ b/styleguide/derek/global-components/social/social-tracking.js
@@ -12,14 +12,8 @@ Zoolander.SocialTracking = (() => {
           socialAction: 'share',
           socialTarget: e.view.location.href,
         });
-        if (typeof FB !== 'undefined') {
-          FB.ui({
-            method: 'share',
-            href: e.view.location.href,
-            hashtag: '#rackspace',
-            quote: 'Checkout this resource from Rackspace',
-          });
-        }
+        const url = encodeURIComponent(e.view.location.href);
+        window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 'fbshare', 'height=500,width=670,left=50%,top=50%');
       });
     }
   }
@@ -91,15 +85,7 @@ Zoolander.SocialTracking = (() => {
   };
 })();
 
-// Facebook Share Tracking
-window.fbAsyncInit = () => {
-  FB.init({
-    appId: '2330309597194845',
-    xfbml: true,
-    version: 'v2.10',
-  });
-  FB.AppEvents.logPageView();
-};
+// Facebook share tracking.
 Zoolander.SocialTracking.facebook();
 
 // Twitter Share Tracking
@@ -117,6 +103,3 @@ if (typeof IN !== 'undefined') {
     Zoolander.SocialTracking.linkedin();
   });
 }
-
-// Email Share Tracking
-Zoolander.SocialTracking.email();

--- a/styleguide/derek/global-components/social/social-tracking.spec.js
+++ b/styleguide/derek/global-components/social/social-tracking.spec.js
@@ -44,19 +44,37 @@ describe('Zoolander Social Tracking Module', () => {
     });
 
     it('should track linkedin share clicks', () => {
-      $('body').append('<div class="IN-widget">Email</div>');
+      $('body').append('<div class="IN-widget">LinkedIn</div>');
       Zoolander.SocialTracking.linkedin();
 
-      const e = document.createEvent('MouseEvents');
-      e.initMouseEvent('click', true, true, window);
-      $('.IN-widget')[0].dispatchEvent(e);
-      const expected = {
-        event: 'social.click',
-        socialNetwork: 'LinkedIn',
-        socialAction: 'share',
-        socialTarget: 'http://localhost:9876/context.html',
-      };
-      expect(window.dataLayer.pop(), 'to push email share event').to.eql(expected);
+      // Initially the datalayer should be empty.
+      expect(window.dataLayer.pop(), 'to not have pushed linkedin share event yet').to.not.exist;
+
+      // After 110ms, the datalayer should contain the event data.
+      setTimeout(() => {
+        const e = document.createEvent('MouseEvents');
+        e.initMouseEvent('click', true, true, window);
+        $('.IN-widget')[0].dispatchEvent(e);
+
+        const expected = {
+          event: 'social.click',
+          socialNetwork: 'LinkedIn',
+          socialAction: 'share',
+          socialTarget: 'http://localhost:9876/context.html',
+        };
+        expect(window.dataLayer.pop(), 'to push linkedin share event').to.eql(expected);
+      }, 110);
+    });
+
+    it('should skip tracking linkedin share clicks if too much time lapses', () => {
+      Zoolander.SocialTracking.linkedin();
+      // Initially the datalayer should be empty.
+      expect(window.dataLayer.pop(), 'to not have pushed linkedin share event yet').to.not.exist;
+
+      // After 310ms, datalayer should still be empty, due to missing IN-widget.
+      setTimeout(() => {
+        expect(window.dataLayer.pop(), 'to not have pushed linkedin share event yet').to.not.exist;
+      }, 310);
     });
 
     it('should track email share clicks', () => {

--- a/styleguide/derek/global-components/social/social.ejs
+++ b/styleguide/derek/global-components/social/social.ejs
@@ -1,27 +1,7 @@
 <!-- LinkedIn JS -->
 <script src="//platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
 
-<!-- Facebook JS -->
-<script>
-window.fbAsyncInit = function() {
-    FB.init({
-      appId      : '2330309597194845',
-      xfbml      : true,
-      version    : 'v2.10'
-    });
-    FB.AppEvents.logPageView();
-  };
-
-  (function(d, s, id){
-     var js, fjs = d.getElementsByTagName(s)[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement(s); js.id = id;
-     js.src = "//connect.facebook.net/en_US/sdk.js";
-     fjs.parentNode.insertBefore(js, fjs);
-   }(document, 'script', 'facebook-jssdk'));
-</script>
-
-<!-- Twiiter JS -->
+<!-- Twitter JS -->
 <script>
 window.twttr = (function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0],
@@ -56,35 +36,7 @@ window.twttr = (function(d, s, id) {
 <div class="social-button social-twitterWrapper">
   <a href="https://twitter.com/intent/tweet?text=Checkout this resource from @Rackspace" class="twitter-share-button" data-show-count="false">Tweet</a>
 </div>
-<div class="social-button social-googleplusWrapper">
-  <div class="g-plus" data-action="share"></div>
-</div>
-<div class="social-button social-emailWrapper">
-  <a class="social-shareEmail" href="mailto:?subject=Checkout this great resource from Rackspace&body=I found this great resource from Rackspace. http://www.rackspace.com" >Email</a>
-</div>
 
 <!--[/social-tracking]-->
 <script src="../../../js/global-components/tracking/tracking.js" charset="utf-8"></script>
 <script src="../../../js/global-components/social/social-tracking.js" charset="utf-8"></script>
-<script>
-// Twitter Share Tracking
-if (typeof twttr !== 'undefined') {
-  twttr.ready((twttr) => {
-    twttr.events.bind('click', (e) => {
-      Zoolander.SocialTracking.twitter(e);
-    });
-  });
-}
-
-// LinkedIn Share Tracking
-IN.Event.onOnce(IN, 'systemReady', () => {
-  Zoolander.SocialTracking.linkedin();
-});
-
-// Facebook Share Tracking
-Zoolander.SocialTracking.facebook();
-
-// Email Share Tracking
-Zoolander.SocialTracking.email();
-</script>
-

--- a/styleguide/derek/templates/thought-leadership-overview/article.ejs
+++ b/styleguide/derek/templates/thought-leadership-overview/article.ejs
@@ -115,7 +115,7 @@
 
   <div class="rsTl-article-row">
     <div class="rsTl-column">
-      <%- partial('_partials/social-links') %>
+      <%- partial('../../global-components/social/social.ejs') %>
     </div>
   </div>
 


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/MTE-5223

This PR resolves an issue with LinkedIn share buttons. See ticket for details, but essentially what was happening is at the point the `systemReady` event fired, the `IN-widget` class wasn't actually rendered yet. Looking through the [LinkedIn SDK docs](https://developer.linkedin.com/docs/js-sdk/api-reference/inauth_inevent_inui#content-par_longformtext_2), there does not appear to be an event that fires any later than `systemReady` so we can't rely on LinkedIn to know when that button is rendered. So what I've done instead is allowed for up to 300ms of time after `systemReady` for it to load, checking every 100ms. All of the tests I've done show it only needing one iteration through the interval, but I've allowed for 3 just in case. If it takes any longer than that, I think we're okay losing tracking here. 

This is definitely a hacky solution, but I don't see any way around it given the limitations of the LinkedIn API. 

Here's a screenshot of it working on a test environment: 
![image](https://user-images.githubusercontent.com/5263371/70068853-615df480-15b6-11ea-832d-71b76a6c092b.png)
