### PR TITLE
MTE-5235: Fix overlay issue

### DIFF
--- a/styleguide/derek/templates/thought-leadership-overview/article.ejs
+++ b/styleguide/derek/templates/thought-leadership-overview/article.ejs
@@ -1,5 +1,5 @@
 <!-- article header section -->
-<a class="rsTl-feature-header" href="#">
+<div class="rsTl-feature-header">
   <picture class="rsTl-feature-headerBackground">
      <!--[if IE 9]><video style="display: none;"><![endif]-->
     <source class="rsTl-feature-headerBackgroundContent" srcset="https://752f77aa107738c25d93-f083e9a6295a3f0714fa019ffdca65c3.ssl.cf1.rackcdn.com/bananers/solve/primary_hero_1600x680_b_12.jpg 1x" media="all and (min-width: 1600px)" type="image/jpeg"/>
@@ -26,7 +26,7 @@
       </div>
     </div>
   </div>
-</a>
+</div>
 
 <div class="container container-xl">
   <div class="rsTl-article-row">

--- a/styleguide/derek/templates/thought-leadership-overview/solve-nav.js
+++ b/styleguide/derek/templates/thought-leadership-overview/solve-nav.js
@@ -2,7 +2,7 @@
   $.fn.solveNav = function solveNav() {
     const $nav = $(this);
     const $window = $(window);
-    const $content = $nav.nextAll('a').eq(0);
+    const $content = $('.rsTl-feature-header');
     const $dropDowns = $nav.find('.rsTl-nav-ddLink');
     const $linkList = $nav.find('.rsTl-nav-list');
     const $hamburger = $nav.find('.rsTl-nav-hamburgerBtn');


### PR DESCRIPTION
This PR fixes a bug where the solve nav overlaid the banner content.  The DOM structure in zoolander is slightly different in Drupal vs Zoolander, so this is a less specific approach.

Also the article pages themselves should not have the "banner" region be a link.  That's just for the overview app. So I changed from `<a>` to `<div>` in zoolander here to match what's in Drupal. 