### PR TITLE
chore(node): Update packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,41 +1434,33 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
-      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/samsam": "^4.2.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.1.tgz",
+      "integrity": "sha512-7+5S4C4wpug5pzHS+z/63+XUwsH7dtyYELDafoT1QnfruFh7eFjlDWwZXltUB0GLk6y5eMeAt34Bjx8wJ4KfSA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "@sinonjs/text-encoding": {
@@ -1665,12 +1657,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
     },
     "array-includes": {
       "version": "3.1.0",
@@ -3339,43 +3325,30 @@
       }
     },
     "clean-css": {
-      "version": "3.4.28",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-      "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
-      "optional": true,
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
       "requires": {
-        "commander": "2.8.x",
-        "source-map": "0.4.x"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "optional": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
     "cli": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.3.tgz",
-      "integrity": "sha1-ewzT3pkORSklZnwNuv/cn38qmhU=",
-      "optional": true,
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "^7.0.5"
+        "glob": "^7.1.1"
       }
     },
     "cli-cursor": {
@@ -5043,8 +5016,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "optional": true
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -6529,6 +6501,35 @@
         "uglify-js": "2.6.x"
       },
       "dependencies": {
+        "clean-css": {
+          "version": "3.4.28",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+          "optional": true,
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          }
+        },
+        "cli": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.3.tgz",
+          "integrity": "sha1-ewzT3pkORSklZnwNuv/cn38qmhU=",
+          "optional": true,
+          "requires": {
+            "exit": "0.1.2",
+            "glob": "^7.0.5"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "optional": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
         "concat-stream": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
@@ -6558,6 +6559,15 @@
             "process-nextick-args": "~1.0.6",
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
           }
         },
         "string_decoder": {
@@ -7138,6 +7148,36 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "optional": true
+        },
+        "clean-css": {
+          "version": "3.4.28",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+          "optional": true,
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+              "optional": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "optional": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
         },
         "cliui": {
           "version": "2.1.0",
@@ -7835,6 +7875,12 @@
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
@@ -7893,10 +7939,13 @@
       }
     },
     "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -8350,15 +8399,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
-      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^4.1.0",
+        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       }
     },
@@ -10942,27 +10992,39 @@
       "optional": true
     },
     "sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz",
+      "integrity": "sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.1",
+        "diff": "^4.0.1",
+        "lolex": "^5.1.2",
+        "nise": "^3.0.1",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "braces": "^3.0.2",
     "browser-sync": "^2.26.7",
     "chai": "^4.2.0",
+    "clean-css": "^4.1.11",
+    "cli": "^1.0.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-chai-friendly": "^0.5.0",
@@ -64,7 +66,7 @@
     "sass-lint": "^1.13.1",
     "semver": "^7.1.1",
     "shortid": "^2.2.15",
-    "sinon": "^7.5.0",
+    "sinon": "^8.0.2",
     "sinon-chai": "^3.4.0",
     "walk": "^2.3.14"
   },


### PR DESCRIPTION
This PR updates a few packages I missed in #745 
- `clean-css` and `cli` needed to be updated explicitly due to minor security issues with the versions that come packaged with harp. 
- `sinon` just needs to be updated to the latest version. 