### PR TITLE
fix(style): icon font size for key offers

### DIFF
--- a/styleguide/_themes/global/scss/fonts.scss
+++ b/styleguide/_themes/global/scss/fonts.scss
@@ -157,7 +157,9 @@ i {
   line-height: 1;
   speak: none;
   text-transform: none;
+}
 
+span {
   &.rsweb {
     font-family: 'rswebfonts';
     font-size: 4.5em;

--- a/styleguide/_themes/global/scss/rsweb-font-style.scss
+++ b/styleguide/_themes/global/scss/rsweb-font-style.scss
@@ -83,7 +83,7 @@ $font-version: "1.0.5";
     }
 }
 
-i.rsweb {
+span.rsweb {
     /* use !important to prevent issues with browser extensions that change fonts */
     font-family: 'rswebfonts' !important;
     speak: none;


### PR DESCRIPTION
This looked to be more of an issue with the key offers widget. 