### PR TITLE
fix(ca): Adjust trigger style to allow for inline content

### DIFF
--- a/styleguide/derek/pattern-components/gated-content/_gated-modal.scss
+++ b/styleguide/derek/pattern-components/gated-content/_gated-modal.scss
@@ -9,10 +9,6 @@ $link-state: rgba($black, .04);
   width: 90%;
 }
 
-.rs-gatedContent-trigger {
-  display: block;
-}
-
 .rs-gated-modalContent {
   border: 0;
   min-height: $modal-height;

--- a/styleguide/derek/pattern-components/gated-content/gated-modal.ejs
+++ b/styleguide/derek/pattern-components/gated-content/gated-modal.ejs
@@ -1,12 +1,13 @@
-<p>
-  <!-- triggers need to be in order with no other children -->
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="0">Cloud Security Solutions</a>
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="1">Cloud Native Solutions</a>
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="2">Modernization Solutions</a>
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="3">Optimization Solutions</a>
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="4">Video</a>
-  <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="5">Video</a>
-</p>
+<ul>
+  <li><a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="0">Cloud Security Solutions (0)</a></li>
+  <li><a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="5">Video (5)</a></li>
+  <li><a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="1">Cloud Native Solutions (1)</a></li>
+</ul>
+<ul>
+  <li><a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="3">Optimization Solutions (3)</a></li>
+  <li><a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="4">Video (4)</a></li>
+  <li>This one can <a class="rs-gatedContent-trigger" data-toggle="modal" data-target="#gated-content" data-index="2">happen in the middle</a> of a sentence.</li>
+</ul>
 
 <!-- Gated Content Modal -->
 <div class="modal fade" id="gated-content" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">


### PR DESCRIPTION
This PR removes the `.rs-gatedContent-trigger` style so content can be used inline. 

I also modified the sample markup to show triggers in a different order, and across multiple HTML elements, just to illustrate that it is possible to do so. 